### PR TITLE
fix(module:page-header): breadcrumb display error menu if component without parameters

### DIFF
--- a/packages/abc/page-header/page-header.component.ts
+++ b/packages/abc/page-header/page-header.component.ts
@@ -13,7 +13,7 @@ import {
   Renderer2,
   OnDestroy,
 } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterEvent, NavigationEnd } from '@angular/router';
 import { NzAffixComponent } from 'ng-zorro-antd';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -51,7 +51,7 @@ export class PageHeaderComponent
     if (this._menus) {
       return this._menus;
     }
-    this._menus = this.menuSrv.getPathByUrl(this.route.url.split('?')[0], this.recursiveBreadcrumb);
+    this._menus = this.menuSrv.getPathByUrl(this.router.url.split('?')[0], this.recursiveBreadcrumb);
 
     return this._menus;
   }
@@ -146,7 +146,7 @@ export class PageHeaderComponent
     cog: PageHeaderConfig,
     settings: SettingsService,
     private renderer: Renderer2,
-    private route: Router,
+    private router: Router,
     private menuSrv: MenuService,
     @Optional()
     @Inject(ALAIN_I18N_TOKEN)
@@ -237,6 +237,12 @@ export class PageHeaderComponent
   ngOnInit() {
     this.refresh();
     this.inited = true;
+    this.router.events.subscribe((event: RouterEvent) => {
+      if (event instanceof NavigationEnd) {
+        this._menus = [];
+        this.refresh();
+      }
+    });
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
fix(module:page-header): breadcrumb display error if one component with several menus.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If a route is like the following situation:

`
    { path: '/example/:id', component: ExampleComponent}
`

And several menus are like the following configuration:

    { "text": "A Path", "link": "/example/1" }    
    { "text": "B Path", "link": "/example/2" }    

And ExampleComponent's template use module page-header without any parameters( such as  "<page-header></page-header>",

When route had changed from menu "A Path" to menu "B Path", the breadcrumb still shown "A Path".
 

## What is the new behavior?

Breadcrumb will show correct menu name.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
