### PR TITLE
fix(module:utils): remove 'yuan'

### DIFF
--- a/packages/schematics/application/files/src/app/shared/index.ts
+++ b/packages/schematics/application/files/src/app/shared/index.ts
@@ -1,7 +1,7 @@
 // Components
 
 // Utils
-export * from './utils/yuan';
+export * from './utils';
 
 // Module
 export * from './shared.module';


### PR DESCRIPTION
最新版出现一个问题：当执行`ng add ng-alain`生成应用后，再执行ng serve会报编译错误:ERROR in src/app/shared/index.ts(4,15): error TS2307: Cannot find module './utils/yuan'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
