### PR TITLE
feat(abc:st): add `filteredlist` property

### DIFF
--- a/packages/abc/table/table-data-source.ts
+++ b/packages/abc/table/table-data-source.ts
@@ -47,8 +47,10 @@ export interface STDataSourceResult {
   ps: number;
   /** 新 `total`，若返回 `undefined` 表示用户受控 */
   total: number;
-  /** 数据 */
+  /** 第一页显示的数据 */
   list: STData[];
+  /** 所有显示的数据 */
+  filteredlist: STData[];
   /** 统计数据 */
   statistical: STStatisticalResults;
 }
@@ -74,6 +76,7 @@ export class STDataSource {
       let retTotal: number;
       let retPs: number;
       let retList: STData[];
+      let retfilteredList: STData[];
       let retPi: number;
       let rawData: any;
       let showPage = page.show;
@@ -139,6 +142,7 @@ export class STDataSource {
                 }
                 result = result.filter(record => values.some(v => onFilter(v, record)));
               });
+            retfilteredList = result;
             return result;
           }),
           // paging
@@ -184,6 +188,7 @@ export class STDataSource {
             ps: retPs,
             total: retTotal,
             list: retList,
+            filteredlist: retfilteredList,
             statistical: this.genStatistical(columns, retList, rawData),
             pageShow: typeof showPage === 'undefined' ? realTotal > realPs : showPage,
           });

--- a/packages/abc/table/table.component.ts
+++ b/packages/abc/table/table.component.ts
@@ -76,6 +76,7 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   private clonePage: STPage;
   private copyCog: STConfig;
   _data: STData[] = [];
+  _filtereddata: STData[] = [];
   _statistical: STStatisticalResults = {};
   _isPagination = true;
   _allChecked = false;
@@ -318,6 +319,7 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
         }
         this._data = result.list as STData[];
         this._statistical = result.statistical as STStatisticalResults;
+        this._filtereddata = result.filteredlist as STData[];
         return this._data;
       })
       .then(() => this._refCheck())

--- a/packages/abc/table/test/table-data-source.spec.ts
+++ b/packages/abc/table/test/table-data-source.spec.ts
@@ -108,6 +108,14 @@ describe('abc: table: data-souce', () => {
             done();
           });
         });
+        it('should return all filtereddata even if page.show is true', done => {
+          options.page.show = true;
+          srv.process(options).then(res => {
+            expect(res.pageShow).toBe(true);
+            expect(res.filteredlist!.length).toBe(DEFAULT.total);
+            done();
+          });
+        });
       });
       describe('without front', () => {
         beforeEach(() => {
@@ -202,6 +210,12 @@ describe('abc: table: data-souce', () => {
         const expectCount = (options.data as any[]).filter(w => w.name.includes(`1`)).length;
         srv.process(options).then(res => {
           expect(res.list.length).toBe(expectCount);
+          done();
+        });
+      });
+      it('should return all filtereddata', done => {
+        srv.process(options).then(res => {
+          expect(res.filteredlist!.length).toBe(res.total);
           done();
         });
       });


### PR DESCRIPTION
The '_data' only reflects the first page, I need a property as same as the 'dataSource.filteredData' in google material mat-table, it reflects all the page even if page.show is true.

Issue: https://github.com/ng-alain/ng-alain/issues/1102

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1102


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
