### PR TITLE
feat(abc:table): add `keepEmptyKey` of mulitisort

### DIFF
--- a/packages/abc/table/index.en-US.md
+++ b/packages/abc/table/index.en-US.md
@@ -213,6 +213,7 @@ Property | Description | Type | Default
 `[separator]` | Separator between attributes | `string` | `-`
 `[nameSeparator]` | Column name and state separator | `string` | `.`
 `[global]` | Whether global multi sort mode<br>`true` all `st` defaults multi-sort<br>`false` all `st` non-multiple sorting, just only configurable for rule | `boolean` | `true`
+`[keepEmptyKey]` | Whether to keep send empty key<br>`true` send the `key` name anyway<br>`false` don't send `key` when not sorting | `boolean` | `true`
 
 ### STData
 

--- a/packages/abc/table/index.zh-CN.md
+++ b/packages/abc/table/index.zh-CN.md
@@ -206,6 +206,7 @@ class TestComponent {
 `[separator]` | 不同属性间分隔符 | `string` | `-`
 `[nameSeparator]` | 列名与状态间分隔符 | `string` | `.`
 `[global]` | 是否全局多排序模式<br>`true` 表示所有 `st` 默认为多排序<br>`false` 表示需要为每个 `st` 添加 `multiSort` 才会视为多排序模式 | `boolean` | `true`
+`[keepEmptyKey]` | 是否保持空值的键名<br>`true` 表示不管是否有排序都会发送 `key` 键名<br>`false` 表示无排序动作时不会发送 `key` 键名 | `boolean` | `true`
 
 ### STData
 

--- a/packages/abc/table/table-column-source.ts
+++ b/packages/abc/table/table-column-source.ts
@@ -5,14 +5,7 @@ import { deepCopy } from '@delon/util';
 
 import { STRowSource } from './table-row.directive';
 import { STConfig } from './table.config';
-import { STColumn, STColumnButton, STColumnFilter, STColumnSort, STIcon, STColumnButtonPop } from './table.interfaces';
-
-export interface STSortMap extends STColumnSort {
-  [key: string]: any;
-
-  /** 是否启用排序 */
-  enabled?: boolean;
-}
+import { STColumn, STColumnButton, STColumnFilter, STSortMap, STIcon, STColumnButtonPop } from './table.interfaces';
 
 @Injectable()
 export class STColumnSource {
@@ -146,6 +139,15 @@ export class STColumnSource {
   }
 
   private sortCoerce(item: STColumn): STSortMap {
+    const res = this.fixCoerce(item);
+    res.reName = {
+      ...this.cog.sortReName,
+      ...res.reName,
+    };
+    return res;
+  }
+
+  private fixCoerce(item: STColumn): STSortMap {
     // compatible
     if (item.sorter && typeof item.sorter === 'function') {
       return {

--- a/packages/abc/table/table-data-source.ts
+++ b/packages/abc/table/table-data-source.ts
@@ -6,7 +6,6 @@ import { deepCopy, deepGet } from '@delon/util';
 import { of, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { STSortMap } from './table-column-source';
 import {
   STColumn,
   STData,
@@ -23,6 +22,7 @@ import {
   STStatisticalResults,
   STStatisticalType,
   STColumnFilter,
+  STSortMap,
 } from './table.interfaces';
 
 export interface STDataSourceOptions {
@@ -286,7 +286,7 @@ export class STDataSource {
   // #region sort
 
   private getValidSort(columns: STColumn[]): STSortMap[] {
-    return columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort);
+    return columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort!);
   }
 
   private getSorterFn(columns: STColumn[]) {
@@ -339,6 +339,9 @@ export class STDataSource {
           .map(item => item.key + ms.nameSeparator + ((item.reName || {})[item.default!] || item.default))
           .join(ms.separator),
       };
+      if (multiSort.keepEmptyKey === false && ret[ms.key].length === 0) {
+        ret = {};
+      }
     } else {
       const mapData = sortList[0];
       let sortFiled = mapData.key;

--- a/packages/abc/table/table.component.ts
+++ b/packages/abc/table/table.component.ts
@@ -503,10 +503,10 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   sort(col: STColumn, idx: number, value: any) {
     if (this.multiSort) {
-      col._sort.default = value;
-      col._sort.tick = this.dataSource.nextSortTick;
+      col._sort!.default = value;
+      col._sort!.tick = this.dataSource.nextSortTick;
     } else {
-      this._columns.forEach((item, index) => (item._sort.default = index === idx ? value : null));
+      this._columns.forEach((item, index) => (item._sort!.default = index === idx ? value : null));
     }
     this.loadPageData();
     const res = {
@@ -518,7 +518,7 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   clearSort() {
-    this._columns.forEach(item => (item._sort.default = null));
+    this._columns.forEach(item => (item._sort!.default = null));
     return this;
   }
 

--- a/packages/abc/table/table.interfaces.ts
+++ b/packages/abc/table/table.interfaces.ts
@@ -339,6 +339,9 @@ export interface STColumn {
    */
   statistical?: STStatisticalType | STStatistical;
 
+  /** @ignore internal property */
+  _sort?: STSortMap;
+
   [key: string]: any;
 }
 
@@ -395,7 +398,7 @@ export interface STColumnSort {
   /**
    * 排序的默认受控属性
    */
-  default?: 'ascend' | 'descend';
+  default?: 'ascend' | 'descend' | null;
   /**
    * 本地数据的排序函数，使用一个函数(参考 [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) 的 compareFunction)
    * - `null` 忽略本地排序，但保持排序功能
@@ -413,6 +416,13 @@ export interface STColumnSort {
    * - `{ ascend: 'asc', descend: 'desc' }` 结果 `?name=desc&pi=1`
    */
   reName?: { ascend?: string; descend?: string };
+}
+
+export interface STSortMap extends STColumnSort {
+  [key: string]: any;
+
+  /** 是否启用排序 */
+  enabled?: boolean;
 }
 
 export interface STColumnFilter {
@@ -795,7 +805,9 @@ export interface STResReNameType {
 }
 
 export interface STExportOptions {
+  /** @ignore internal property */
   _d?: any[];
+  /** @ignore internal property */
   _c?: STColumn[];
   /** 工作溥名 */
   sheetname?: string;
@@ -833,6 +845,12 @@ export interface STMultiSort {
    * - `false` 表示需要为每个 `st` 添加 `multiSort` 才会视为多排序模式
    */
   global?: boolean;
+  /**
+   * 是否保持空值的键名，默认：`true`
+   * - `true` 表示不管是否有排序都会发送 `key` 键名
+   * - `false` 表示无排序动作时不会发送 `key` 键名
+   */
+  keepEmptyKey?: boolean;
 }
 
 /**

--- a/packages/abc/table/test/table-column-source.spec.ts
+++ b/packages/abc/table/test/table-column-source.spec.ts
@@ -216,27 +216,27 @@ describe('abc: table: column-souce', () => {
     describe('[sort]', () => {
       describe('#compatible', () => {
         it('should be enabled', () => {
-          expect(srv.process([{ title: '', sorter: () => true }])[0]._sort.enabled).toBe(true);
+          expect(srv.process([{ title: '', sorter: () => true }])[0]._sort!.enabled).toBe(true);
         });
       });
       it('should be disabled', () => {
-        expect(srv.process([{ title: '' }])[0]._sort.enabled).toBe(false);
+        expect(srv.process([{ title: '' }])[0]._sort!.enabled).toBe(false);
       });
       it('should be enabled when is true', () => {
-        expect(srv.process([{ title: '', sort: true }])[0]._sort.enabled).toBe(true);
+        expect(srv.process([{ title: '', sort: true }])[0]._sort!.enabled).toBe(true);
       });
       it('should be enabled when is string', () => {
-        const res = srv.process([{ title: '', sort: 'true' }])[0]._sort;
+        const res = srv.process([{ title: '', sort: 'true' }])[0]._sort!;
         expect(res.enabled).toBe(true);
         expect(res.key).toBe('true');
       });
       it('should be enabled when is object', () => {
-        const res = srv.process([{ title: '', sort: { default: 'ascend' } }])[0]._sort;
+        const res = srv.process([{ title: '', sort: { default: 'ascend' } }])[0]._sort!;
         expect(res.enabled).toBe(true);
         expect(res.default).toBe('ascend');
       });
       it('should be used index when key is null', () => {
-        const res = srv.process([{ title: '', index: 'aa', sort: { key: null } }])[0]._sort;
+        const res = srv.process([{ title: '', index: 'aa', sort: { key: null } }])[0]._sort!;
         expect(res.enabled).toBe(true);
         expect(res.key).toBe('aa');
       });

--- a/packages/abc/table/test/table-data-source.spec.ts
+++ b/packages/abc/table/test/table-data-source.spec.ts
@@ -164,7 +164,7 @@ describe('abc: table: data-souce', () => {
       });
       it(`should be decremented`, done => {
         options.data[1].id = 100000;
-        options.columns[0]._sort.default = 'descend';
+        options.columns[0]._sort!.default = 'descend';
         srv.process(options).subscribe(res => {
           expect(res.list[0].id).toBe(100000);
           done();
@@ -172,7 +172,7 @@ describe('abc: table: data-souce', () => {
       });
       it(`should be incremented`, done => {
         options.data[1].id = -100000;
-        options.columns[0]._sort.default = 'ascend';
+        options.columns[0]._sort!.default = 'ascend';
         srv.process(options).subscribe(res => {
           expect(res.list[0].id).toBe(-100000);
           done();
@@ -447,30 +447,30 @@ describe('abc: table: data-souce', () => {
         });
       });
       it(`should be decremented`, done => {
-        options.columns[0]._sort.default = 'descend';
+        options.columns[0]._sort!.default = 'descend';
         srv.process(options).subscribe(() => {
           expect(resParams.id).toBe('descend');
           done();
         });
       });
       it(`should be incremented`, done => {
-        options.columns[0]._sort.default = 'ascend';
+        options.columns[0]._sort!.default = 'ascend';
         srv.process(options).subscribe(() => {
           expect(resParams.id).toBe('ascend');
           done();
         });
       });
       it(`should be re-name`, done => {
-        options.columns[0]._sort.default = 'ascend';
-        options.columns[0]._sort.reName = { ascend: 'A', descend: 'D' };
+        options.columns[0]._sort!.default = 'ascend';
+        options.columns[0]._sort!.reName = { ascend: 'A', descend: 'D' };
         srv.process(options).subscribe(() => {
           expect(resParams.id).toBe('A');
           done();
         });
       });
       it(`should be used default key when invalid re-name paraments`, done => {
-        options.columns[0]._sort.default = 'ascend';
-        options.columns[0]._sort.reName = {};
+        options.columns[0]._sort!.default = 'ascend';
+        options.columns[0]._sort!.reName = {};
         srv.process(options).subscribe(() => {
           expect(resParams.id).toBe('ascend');
           done();
@@ -503,22 +503,44 @@ describe('abc: table: data-souce', () => {
           });
         });
         it(`should be re-name`, done => {
-          options.columns[0]._sort.reName = { ascend: 'A', descend: 'D' };
+          options.columns[0]._sort!.reName = { ascend: 'A', descend: 'D' };
           srv.process(options).subscribe(() => {
             expect(resParams.SORT).toBe('id1.D-id2.ascend');
             done();
           });
         });
+        it(`should be removed key when no any sort of keepEmptyKey is false`, done => {
+          options.multiSort = {
+            ...options.multiSort,
+            keepEmptyKey: false,
+          };
+          options.columns = [
+            {
+              title: '',
+              index: 'id1',
+              sort: true,
+            },
+            {
+              title: '',
+              index: 'id2',
+              sort: true,
+            },
+          ];
+          srv.process(options).subscribe(() => {
+            expect(resParams.SORT).toBeUndefined();
+            done();
+          });
+        });
         it(`should be used default key when invalid re-name paraments`, done => {
-          options.columns[0]._sort.reName = {};
+          options.columns[0]._sort!.reName = {};
           srv.process(options).subscribe(() => {
             expect(resParams.SORT).toBe('id1.descend-id2.ascend');
             done();
           });
         });
         it(`should be in user order`, done => {
-          options.columns[1]._sort.tick = srv.nextSortTick;
-          options.columns[0]._sort.tick = srv.nextSortTick;
+          options.columns[1]._sort!.tick = srv.nextSortTick;
+          options.columns[0]._sort!.tick = srv.nextSortTick;
           srv.process(options).subscribe(() => {
             expect(resParams.SORT).toBe('id2.ascend-id1.descend');
             done();
@@ -527,7 +549,7 @@ describe('abc: table: data-souce', () => {
       });
       describe('[singleSort]', () => {
         it(`should working`, done => {
-          options.columns[0]._sort.default = 'ascend';
+          options.columns[0]._sort!.default = 'ascend';
           options.singleSort = {};
           srv.process(options).subscribe(() => {
             expect(resParams.sort).toBe('id.ascend');
@@ -535,7 +557,7 @@ describe('abc: table: data-souce', () => {
           });
         });
         it(`should specify options`, done => {
-          options.columns[0]._sort.default = 'ascend';
+          options.columns[0]._sort!.default = 'ascend';
           options.singleSort = { key: 'SORT', nameSeparator: '-' };
           srv.process(options).subscribe(() => {
             expect(resParams.SORT).toBe('id-ascend');

--- a/packages/abc/table/test/table.spec.ts
+++ b/packages/abc/table/test/table.spec.ts
@@ -1348,7 +1348,7 @@ describe('abc: table', () => {
           it('should be sorting', () => {
             fixture.detectChanges();
             comp.sort(comp._columns[0], 0, 'descend');
-            const sortList = comp._columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort);
+            const sortList = comp._columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort!);
             expect(sortList.length).toBe(1);
             expect(sortList[0].default).toBe('descend');
           });
@@ -1359,7 +1359,7 @@ describe('abc: table', () => {
             fixture.detectChanges();
             comp.sort(comp._columns[0], 0, 'descend');
             comp.sort(comp._columns[1], 0, 'ascend');
-            const sortList = comp._columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort);
+            const sortList = comp._columns.filter(item => item._sort && item._sort.enabled && item._sort.default).map(item => item._sort!);
             expect(sortList.length).toBe(2);
             expect(sortList[0].default).toBe('descend');
             expect(sortList[1].default).toBe('ascend');


### PR DESCRIPTION
fix(abc:table): fix invalid global `sortReName` property in mulitisort

- close https://github.com/ng-alain/ng-alain/issues/1399

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
