### PR TITLE
优化sf array的grid布局配置

### DIFF
--- a/packages/form/src/sf.component.ts
+++ b/packages/form/src/sf.component.ts
@@ -338,7 +338,7 @@ export class SFComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         if (property.items) {
-          uiRes[uiKey].$items = uiRes[uiKey].$items || {};
+          uiRes[uiKey].$items = uiRes[uiKey].$items || { ...property.items.ui };
           inFn(property.items, property.items, (uiSchema[uiKey] || {}).$items || {}, ui, uiRes[uiKey].$items);
         }
 


### PR DESCRIPTION
sf组件array控件使用object进行表单渲染，而object中存在*ngIf="grid; else noGrid"的判断，array中使用items进行properties配置，在SFSchema中继承和配置的ui属性无效
通过在ui $items初始化时加入SFSchema的配置内容可以部分实现grid布局，但是这样仍然存在无法继承ui配置的问题。

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
sf组件的array控件对grid配置无响应，

Issue Number: N/A


## What is the new behavior?
sf组件将读取array中items配置的ui属性

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
