### PR TITLE
fix(abc:st): fix `width` can't be reset when refresh group columns

### DIFF
--- a/packages/abc/st/st.component.html
+++ b/packages/abc/st/st.component.html
@@ -83,7 +83,7 @@
   [nzShowSizeChanger]="page.showSize"
   [nzPaginationPosition]="page.position"
   [nzShowTotal]="totalTpl"
-  [nzWidthConfig]="widthConfig"
+  [nzWidthConfig]="_widthConfig"
 >
   <thead class="st__head">
     <tr *ngFor="let row of _headers; let rowFirst = first">

--- a/packages/abc/st/st.component.ts
+++ b/packages/abc/st/st.component.ts
@@ -169,7 +169,7 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input()
   set widthConfig(val: string[]) {
     this._widthConfig = val;
-    this.customWidthConfig = true;
+    this.customWidthConfig = val && val.length > 0;
   }
   @Input() header: string | TemplateRef<void>;
   @Input() footer: string | TemplateRef<void>;

--- a/packages/abc/st/st.component.ts
+++ b/packages/abc/st/st.component.ts
@@ -91,6 +91,8 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   private _res: STRes;
   private _page: STPage;
   private _widthMode: STWidthMode;
+  private customWidthConfig: boolean = false;
+  _widthConfig: string[] = [];
   locale: LocaleData = {};
   _loading = false;
   _data: STData[] = [];
@@ -164,6 +166,11 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   get widthMode(): STWidthMode {
     return this._widthMode;
   }
+  @Input()
+  set widthConfig(val: string[]) {
+    this._widthConfig = val;
+    this.customWidthConfig = true;
+  }
   @Input() header: string | TemplateRef<void>;
   @Input() footer: string | TemplateRef<void>;
   @Input() bodyHeader: TemplateRef<STStatisticalResults>;
@@ -172,7 +179,6 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() @InputBoolean() expandAccordion = false;
   @Input() expand: TemplateRef<{ $implicit: {}; column: STColumn }>;
   @Input() noResult: string | TemplateRef<void>;
-  @Input() widthConfig: string[] = [];
   @Input() @InputNumber() rowClickTime = 200;
   @Input() @InputBoolean() responsive: boolean = true;
   @Input() @InputBoolean() responsiveHideHeaderFooter: boolean;
@@ -793,8 +799,8 @@ export class STComponent implements AfterViewInit, OnChanges, OnDestroy {
     const res = this.columnSource.process(this.columns);
     this._columns = res.columns;
     this._headers = res.headers;
-    if (this.widthConfig.length === 0 && res.headerWidths != null) {
-      this.widthConfig = res.headerWidths;
+    if (this.customWidthConfig === false && res.headerWidths != null) {
+      this._widthConfig = res.headerWidths;
     }
     return this;
   }

--- a/packages/abc/st/test/st.spec.ts
+++ b/packages/abc/st/test/st.spec.ts
@@ -786,6 +786,18 @@ describe('abc: table', () => {
           ]);
           page.expectElCount('.ant-table-thead .ant-table-row', 2).expectElCount('.ant-table-thead .ant-table-cell', 3).asyncEnd();
         }));
+        it('should be auto set widthConfig when column has width value', fakeAsync(() => {
+          page.updateColumn([
+            {
+              title: 'user',
+              children: [
+                { title: 'name', index: 'name' },
+                { title: 'age', index: 'age', width: 100 },
+              ],
+            },
+          ]);
+          page.expectElCount('.ant-table-thead .ant-table-row', 2).expectElCount('.ant-table-thead .ant-table-cell', 3).asyncEnd();
+        }));
       });
     });
     describe('[data source]', () => {


### PR DESCRIPTION
- close https://github.com/ng-alain/ng-alain/issues/1805

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
