### PR TITLE
refactor: forward-compatibility for upcoming type improvements in Angular Pipes

### DIFF
--- a/packages/theme/src/pipes/currency/cn-currency.pipe.ts
+++ b/packages/theme/src/pipes/currency/cn-currency.pipe.ts
@@ -1,18 +1,24 @@
 import { CurrencyPipe } from '@angular/common';
-import { Pipe } from '@angular/core';
+import { Inject, LOCALE_ID, Pipe } from '@angular/core';
 
 /**
  * @see https://ng-alain.com/theme/currency
  */
 // tslint:disable-next-line:use-pipe-transform-interface
 @Pipe({ name: '_currency' })
-export class CNCurrencyPipe extends CurrencyPipe {
+export class CNCurrencyPipe {
+  private readonly ngCurrencyPipe: CurrencyPipe;
+
+  constructor(@Inject(LOCALE_ID) locale: string) {
+      this.ngCurrencyPipe = new CurrencyPipe(locale);
+  }
+
   transform(
     value: any,
     currencyCode: string = '￥',
     display: 'code' | 'symbol' | 'symbol-narrow' | boolean = 'code',
     digits?: string,
   ): string | null {
-    return super.transform(value, currencyCode, display as any, digits);
+    return this.ngCurrencyPipe.transform(value, currencyCode, display as any, digits);
   }
 }


### PR DESCRIPTION
There is an upcoming improvement in common pipes in Angular framework that would be released in the next major version (v11). The changes can be found in https://github.com/angular/angular/pull/37447.

This commit refactors the `CNCurrencyPipe` pipe to provide forward-compatibility for the next major release of Angular framework. The improved typings make `transform` function signature of the mentioned pipe incompatible with the `CurrencyPipe`. This commit updates the `CNCurrencyPipe` pipe to initialize the `CurrencyPipe` in constructor instead of extending it (to keep existing `transform` function signature) and use created instance inside the `transform` function as needed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No