### PR TITLE
docs: typo

### DIFF
--- a/packages/theme/docs/getting-started.zh-CN.md
+++ b/packages/theme/docs/getting-started.zh-CN.md
@@ -4,7 +4,7 @@ title: 开始使用
 type: Documents
 ---
 
-`@delon/theme` 是 ng-alain 架手脚唯一必须引入的模块。它包含了非常多[主题样式参数](/theme/global)，通过覆盖参数数值进而定制一些特别的需求；以及若干通用性[服务](/theme/menu)、[管道](/theme/date)。
+`@delon/theme` 是 ng-alain 脚手架唯一必须引入的模块。它包含了非常多[主题样式参数](/theme/global)，通过覆盖参数数值进而定制一些特别的需求；以及若干通用性[服务](/theme/menu)、[管道](/theme/date)。
 
 ## 样式
 


### PR DESCRIPTION
更正前： @delon/theme 是 ng-alain 架手脚唯一必须引入的模块。
更正后：@delon/theme 是 ng-alain 手脚架唯一必须引入的模块。
