### PR TITLE
Update acl.type.ts

### DIFF
--- a/packages/acl/src/acl.type.ts
+++ b/packages/acl/src/acl.type.ts
@@ -4,7 +4,7 @@
  * TODO: 尝试增加 `@delon/core` 类库用于处理这种通用型
  */
 
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+// import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 export interface ACLType {
   /**
@@ -28,7 +28,7 @@ export interface ACLType {
    */
   except?: boolean;
 
-  [key: string]: NzSafeAny;
+  [key: string]: any;
 }
 
 export type ACLCanType = number | number[] | string | string[] | ACLType;


### PR DESCRIPTION
do we really need to import the full ng-zorro-antd module for use NzSafeAny type inside the ACL package?
