### PR TITLE
fix(abc:qr): fix percent sign lose

### DIFF
--- a/packages/abc/qr/qr.component.ts
+++ b/packages/abc/qr/qr.component.ts
@@ -127,7 +127,7 @@ export class QRComponent implements OnChanges, AfterViewInit, OnDestroy {
       if (str.charAt(i) !== '%') {
         result.push(str.charCodeAt(i));
       } else {
-        result.push(parseInt(str.substr(i + 1, 2), 16));
+        result.push(parseInt(str.substring(i + 1, i + 3), 16));
         i += 2;
       }
     }

--- a/packages/abc/qr/qr.component.ts
+++ b/packages/abc/qr/qr.component.ts
@@ -127,7 +127,7 @@ export class QRComponent implements OnChanges, AfterViewInit, OnDestroy {
       if (str.charAt(i) !== '%') {
         result.push(str.charCodeAt(i));
       } else {
-        result.push(parseInt(str.substring(i + 1, 2), 16));
+        result.push(parseInt(str.substr(i + 1, 2), 16));
         i += 2;
       }
     }


### PR DESCRIPTION
Repair generated QRcode missing percent sign

当url中带有%号时，用substring(i + 1, 2)，会截取%号到第二个字符间的字符串，这不符合预期。比如：
'https://ng-alain.com/?v=a%2Fy'.substring(i + 1, 2)返回：'tps://ng-alain.com/?v=a%'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
