### PR TITLE
fix(cli): remove `skipTests` from generating module

### DIFF
--- a/schematics/application/index.ts
+++ b/schematics/application/index.ts
@@ -203,8 +203,7 @@ function addSchematics(options: ApplicationOptions): Rule {
     const p = getProjectFromWorkspace(workspace, options.project);
     const schematics = p.extensions.schematics;
     schematics['ng-alain:module'] = {
-      routing: true,
-      skipTests: false
+      routing: true
     };
     schematics['ng-alain:list'] = {
       skipTests: false
@@ -221,8 +220,7 @@ function addSchematics(options: ApplicationOptions): Rule {
       skipTests: false
     };
     schematics['@schematics/angular:module'] = {
-      routing: true,
-      skipTests: false
+      routing: true
     };
     schematics['@schematics/angular:component'] = {
       skipTests: false,

--- a/schematics/docs/default.en-US.md
+++ b/schematics/docs/default.en-US.md
@@ -16,33 +16,33 @@ However, parameters can be preset via `angular.json`.
       "routing": true
     },
     "ng-alain:list": {
-      "spec": false
+      "skipTests": false
     },
     "ng-alain:edit": {
-      "spec": false,
+      "skipTests": false,
       "modal": true
     },
     "ng-alain:view": {
-      "spec": false,
+      "skipTests": false,
       "modal": true
     },
     "ng-alain:curd": {
-      "spec": false
+      "skipTests": false
     },
     "@schematics/angular:module": {
       "routing": true
     },
     "@schematics/angular:component": {
-      "spec": false,
+      "skipTests": false,
       "flat": false,
       "inlineStyle": true,
       "inlineTemplate": false
     },
     "@schematics/angular:directive": {
-      "spec": false
+      "skipTests": false
     },
     "@schematics/angular:service": {
-      "spec": false
+      "skipTests": false
     }
   }
 }

--- a/schematics/docs/default.en-US.md
+++ b/schematics/docs/default.en-US.md
@@ -13,8 +13,7 @@ However, parameters can be preset via `angular.json`.
 {
   "schematics": {
     "ng-alain:module": {
-      "routing": true,
-      "spec": false
+      "routing": true
     },
     "ng-alain:list": {
       "spec": false
@@ -31,8 +30,7 @@ However, parameters can be preset via `angular.json`.
       "spec": false
     },
     "@schematics/angular:module": {
-      "routing": true,
-      "spec": false
+      "routing": true
     },
     "@schematics/angular:component": {
       "spec": false,

--- a/schematics/docs/default.zh-CN.md
+++ b/schematics/docs/default.zh-CN.md
@@ -18,33 +18,33 @@ ng-alain 提供诸多生成模块、页模板，但实际上继承了原生 Angu
       "routing": true
     },
     "ng-alain:list": {
-      "spec": false
+      "skipTests": false
     },
     "ng-alain:edit": {
-      "spec": false,
+      "skipTests": false,
       "modal": true
     },
     "ng-alain:view": {
-      "spec": false,
+      "skipTests": false,
       "modal": true
     },
     "ng-alain:curd": {
-      "spec": false
+      "skipTests": false
     },
     "@schematics/angular:module": {
       "routing": true
     },
     "@schematics/angular:component": {
-      "spec": false,
+      "skipTests": false,
       "flat": false,
       "inlineStyle": true,
       "inlineTemplate": false
     },
     "@schematics/angular:directive": {
-      "spec": false
+      "skipTests": false
     },
     "@schematics/angular:service": {
-      "spec": false
+      "skipTests": false
     }
   }
 }

--- a/schematics/docs/default.zh-CN.md
+++ b/schematics/docs/default.zh-CN.md
@@ -15,8 +15,7 @@ ng-alain 提供诸多生成模块、页模板，但实际上继承了原生 Angu
 {
   "schematics": {
     "ng-alain:module": {
-      "routing": true,
-      "spec": false
+      "routing": true
     },
     "ng-alain:list": {
       "spec": false
@@ -33,8 +32,7 @@ ng-alain 提供诸多生成模块、页模板，但实际上继承了原生 Angu
       "spec": false
     },
     "@schematics/angular:module": {
-      "routing": true,
-      "spec": false
+      "routing": true
     },
     "@schematics/angular:component": {
       "spec": false,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Angular CLI: 16.1.4
Node: 20.1.0 (Unsupported)
Package Manager: npm 9.6.4
OS: win32 x64

After running `ng g module xxx`, shows error below

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
Schematic input does not validate against the Schema: {"routing":true,"skipTests":false,"name":"xxx","path":"src/app/routes","project":"frontend"}       
Errors:

  Data path "" must NOT have additional properties(skipTests).

```

And [Angular](https://angular.io/cli/generate#module) and [Delon](https://github.com/ng-alain/delon/blob/master/schematics/module/schema.json) document doesn't present a `skipTests` option.

Issue Number: N/A


## What is the new behavior?
Remove `skipTests` in module generation config.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
