### PR TITLE
fix(abc:pdf): fix ignore dependency `pdfjs-dist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "xlsx": "^0.18.5",
     "jszip": "^3.10.1",
     "plyr": "^3.7.8",
-    "pdfjs-dist": "~3.6.172",
     "screenfull": "^6.0.2",
     "less-bundle-promise": "^1.0.11",
     "ng-alain-codelyzer": "^0.0.1",

--- a/packages/abc/package.json
+++ b/packages/abc/package.json
@@ -26,7 +26,6 @@
     "jszip": "@LIB-PLACEHOLDER",
     "xlsx": "@LIB-PLACEHOLDER",
     "plyr": "@LIB-PLACEHOLDER",
-    "pdfjs-dist": "@LIB-PLACEHOLDER",
     "@github/hotkey": "@LIB-PLACEHOLDER",
     "ngx-countdown": "@LIB-PLACEHOLDER",
     "@delon/theme": "PEER-0.0.0-PLACEHOLDER",

--- a/packages/abc/pdf/demo/design.md
+++ b/packages/abc/pdf/demo/design.md
@@ -193,7 +193,7 @@ export class DemoComponent implements OnInit {
   };
 
   loadOutline(): void {
-    this.comp.pdf?.getOutline().then(outline => {
+    this.comp.pdf?.getOutline().then((outline: NzSafeAny) => {
       this.outlineList = outline;
     });
   }

--- a/packages/abc/pdf/index.en-US.md
+++ b/packages/abc/pdf/index.en-US.md
@@ -15,6 +15,10 @@ pdf.js libary is lazy loading by default，you can change the default root CDN p
 
 **Use local path**
 
+```bash
+yarn add pdfjs-dist
+```
+
 ```json
 // angular.json
 {

--- a/packages/abc/pdf/index.zh-CN.md
+++ b/packages/abc/pdf/index.zh-CN.md
@@ -15,6 +15,10 @@ module: import { PdfModule } from '@delon/abc/pdf';
 
 **使用本地路径**
 
+```bash
+yarn add pdfjs-dist
+```
+
 ```json
 // angular.json
 {

--- a/packages/abc/pdf/pdf.component.ts
+++ b/packages/abc/pdf/pdf.component.ts
@@ -22,11 +22,11 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent, timer, debounceTime, filter } from 'rxjs';
 
-import type { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist';
-import type { EventBus } from 'pdfjs-dist/types/web/event_utils';
-import type { PDFFindController } from 'pdfjs-dist/types/web/pdf_find_controller';
-import type { PDFLinkService } from 'pdfjs-dist/types/web/pdf_link_service';
-import type { PDFViewer } from 'pdfjs-dist/types/web/pdf_viewer';
+// import type { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist';
+// import type { EventBus } from 'pdfjs-dist/types/web/event_utils';
+// import type { PDFFindController } from 'pdfjs-dist/types/web/pdf_find_controller';
+// import type { PDFLinkService } from 'pdfjs-dist/types/web/pdf_link_service';
+// import type { PDFViewer } from 'pdfjs-dist/types/web/pdf_viewer';
 
 import { AlainConfigService } from '@delon/util/config';
 import { BooleanInput, InputBoolean, InputNumber, NumberInput, ZoneOutside } from '@delon/util/decorator';
@@ -35,6 +35,16 @@ import type { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { PDF_DEFULAT_CONFIG } from './pdf.config';
 import { PdfChangeEvent, PdfChangeEventType, PdfExternalLinkTarget, PdfTextLayerMode, PdfZoomScale } from './pdf.types';
+
+// TODO: Although pdfjs-dist is an optional dependency on canvas
+// will be installed automatically when the dependency is installed by default;
+// This requires a higher environment and often fails to install
+type PDFDocumentLoadingTask = NzSafeAny;
+type PDFDocumentProxy = NzSafeAny;
+type EventBus = NzSafeAny;
+type PDFFindController = NzSafeAny;
+type PDFLinkService = NzSafeAny;
+type PDFViewer = NzSafeAny;
 
 const CSS_UNITS: number = 96.0 / 72.0;
 const BORDER_WIDTH = 9;
@@ -325,7 +335,7 @@ export class PdfComponent implements OnChanges, AfterViewInit, OnDestroy {
     const currentViewer = this.pageViewer;
     if (!currentViewer) return;
 
-    this._pdf!.getPage(currentViewer.currentPageNumber).then(page => {
+    this._pdf!.getPage(currentViewer.currentPageNumber).then((page: NzSafeAny) => {
       const { _rotation, _zoom } = this;
       const rotation = _rotation || page.rotate;
       const viewportWidth =

--- a/packages/abc/pdf/pdf.types.ts
+++ b/packages/abc/pdf/pdf.types.ts
@@ -1,6 +1,8 @@
-import type { PDFDocumentProxy } from 'pdfjs-dist';
+// import type { PDFDocumentProxy } from 'pdfjs-dist';
 
 import type { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+type PDFDocumentProxy = NzSafeAny;
 
 export type PdfChangeEventType =
   | 'loaded'

--- a/scripts/site/route-paths.txt
+++ b/scripts/site/route-paths.txt
@@ -75,6 +75,8 @@
 /components/auto-focus/zh
 /components/avatar-list/en
 /components/avatar-list/zh
+/components/cell/en
+/components/cell/zh
 /components/count-down/en
 /components/count-down/zh
 /components/date-picker/en

--- a/src/app/global-config.module.ts
+++ b/src/app/global-config.module.ts
@@ -33,9 +33,9 @@ const alainConfig: AlainConfig = {
   qr: {
     lib: '/assets/qrious/qrious.min.js'
   },
-  pdf: {
-    lib: '/assets/pdfjs/'
-  },
+  // pdf: {
+  //   lib: '/assets/pdfjs/'
+  // },
   media: {
     urls: ['assets/plyr/plyr.min.js', 'assets/plyr/plyr.css'],
     options: {


### PR DESCRIPTION
Although pdfjs-dist is an optional dependency on canvas, Will be installed automatically when the dependency is installed by default; This requires a higher environment and often fails to install

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
