### PR TITLE
perf(theme): remove forRoot and forChild

### DIFF
--- a/packages/form/spec/base.spec.ts
+++ b/packages/form/spec/base.spec.ts
@@ -47,9 +47,7 @@ export function builder(options?: {
 } {
   options = { detectChanges: true, ...options };
   TestBed.configureTestingModule({
-    imports: [NoopAnimationsModule, AlainThemeModule.forRoot(), DelonFormModule.forRoot()].concat(
-      options.imports || []
-    ),
+    imports: [NoopAnimationsModule, AlainThemeModule, DelonFormModule.forRoot()].concat(options.imports || []),
     declarations: [TestFormComponent]
   });
   if (options.template) {
@@ -80,7 +78,7 @@ export function configureSFTestSuite(options?: { imports?: NzSafeAny[] }): void 
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
-        AlainThemeModule.forRoot(),
+        AlainThemeModule,
         DelonFormModule.forRoot(),
         HttpClientTestingModule,
         ...(options?.imports ?? [])

--- a/packages/form/spec/form.spec.ts
+++ b/packages/form/spec/form.spec.ts
@@ -27,10 +27,7 @@ describe('form: component', () => {
 
   function genModule(options: { acl?: boolean; i18n?: boolean } = {}): void {
     options = { acl: false, i18n: false, ...options };
-    const imports = [NoopAnimationsModule, DelonFormModule.forRoot(), AlainThemeModule.forRoot()];
-    if (options.i18n) {
-      imports.push(AlainThemeModule.forRoot());
-    }
+    const imports = [NoopAnimationsModule, DelonFormModule.forRoot(), AlainThemeModule];
     if (options.acl) {
       imports.push(DelonACLModule.forRoot());
     }

--- a/packages/theme/src/pipes/date/date.pipe.spec.ts
+++ b/packages/theme/src/pipes/date/date.pipe.spec.ts
@@ -20,7 +20,7 @@ describe('Pipe: _date', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent],
       providers: [{ provide: NZ_DATE_LOCALE, useValue: dateFnsLang }]
     });

--- a/packages/theme/src/pipes/date/date.pipe.ts
+++ b/packages/theme/src/pipes/date/date.pipe.ts
@@ -3,7 +3,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { formatDate } from '@delon/util/date-time';
 import { NzI18nService } from 'ng-zorro-antd/i18n';
 
-@Pipe({ name: '_date' })
+@Pipe({ name: '_date', standalone: true })
 export class DatePipe implements PipeTransform {
   constructor(private nzI18n: NzI18nService) {}
 

--- a/packages/theme/src/pipes/keys/keys.pipe.spec.ts
+++ b/packages/theme/src/pipes/keys/keys.pipe.spec.ts
@@ -11,7 +11,7 @@ describe('Pipe: keys', () => {
 
   function genModule(template?: string): void {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent]
     });
     if (template) TestBed.overrideTemplate(TestComponent, template);

--- a/packages/theme/src/pipes/keys/keys.pipe.ts
+++ b/packages/theme/src/pipes/keys/keys.pipe.ts
@@ -5,7 +5,7 @@ import type { NzSafeAny } from 'ng-zorro-antd/core/types';
 /**
  * [Document](https://ng-alain.com/theme/keys)
  */
-@Pipe({ name: 'keys' })
+@Pipe({ name: 'keys', standalone: true })
 export class KeysPipe implements PipeTransform {
   transform(value: NzSafeAny, keyIsNumber: boolean = false): NzSafeAny[] {
     const ret: NzSafeAny[] = [];

--- a/packages/theme/src/pipes/safe/html.pipe.spec.ts
+++ b/packages/theme/src/pipes/safe/html.pipe.spec.ts
@@ -9,7 +9,7 @@ describe('Pipe: html', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent]
     });
     fixture = TestBed.createComponent(TestComponent);

--- a/packages/theme/src/pipes/safe/html.pipe.ts
+++ b/packages/theme/src/pipes/safe/html.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
-@Pipe({ name: 'html' })
+@Pipe({ name: 'html', standalone: true })
 export class HTMLPipe implements PipeTransform {
   constructor(private dom: DomSanitizer) {}
 

--- a/packages/theme/src/pipes/safe/url.pipe.spec.ts
+++ b/packages/theme/src/pipes/safe/url.pipe.spec.ts
@@ -9,7 +9,7 @@ describe('Pipe: url', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent]
     });
     fixture = TestBed.createComponent(TestComponent);

--- a/packages/theme/src/pipes/safe/url.pipe.ts
+++ b/packages/theme/src/pipes/safe/url.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 
-@Pipe({ name: 'url' })
+@Pipe({ name: 'url', standalone: true })
 export class URLPipe implements PipeTransform {
   constructor(private dom: DomSanitizer) {}
 

--- a/packages/theme/src/pipes/yn/yn.pipe.spec.ts
+++ b/packages/theme/src/pipes/yn/yn.pipe.spec.ts
@@ -10,7 +10,7 @@ describe('Pipe: yn', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent]
     });
   });

--- a/packages/theme/src/pipes/yn/yn.pipe.ts
+++ b/packages/theme/src/pipes/yn/yn.pipe.ts
@@ -35,7 +35,7 @@ export function yn(value: boolean, opt?: YNOptions): string {
   return html;
 }
 
-@Pipe({ name: 'yn' })
+@Pipe({ name: 'yn', standalone: true })
 export class YNPipe implements PipeTransform {
   constructor(private dom: DomSanitizer) {}
 

--- a/packages/theme/src/services/drawer/drawer.spec.ts
+++ b/packages/theme/src/services/drawer/drawer.spec.ts
@@ -14,7 +14,7 @@ describe('theme: DrawerHelper', () => {
 
   beforeEach(() => {
     @NgModule({
-      imports: [CommonModule, NoopAnimationsModule, AlainThemeModule.forChild(), NzDrawerModule],
+      imports: [CommonModule, NoopAnimationsModule, AlainThemeModule, NzDrawerModule],
       declarations: [TestDrawerComponent, TestComponent]
     })
     class TestModule {}

--- a/packages/theme/src/services/i18n/i18n.pipe.ts
+++ b/packages/theme/src/services/i18n/i18n.pipe.ts
@@ -2,7 +2,7 @@ import { Inject, Pipe, PipeTransform } from '@angular/core';
 
 import { AlainI18NService, ALAIN_I18N_TOKEN } from './i18n';
 
-@Pipe({ name: 'i18n' })
+@Pipe({ name: 'i18n', standalone: true })
 export class I18nPipe implements PipeTransform {
   constructor(@Inject(ALAIN_I18N_TOKEN) private i18n: AlainI18NService) {}
 

--- a/packages/theme/src/services/i18n/i18n.spec.ts
+++ b/packages/theme/src/services/i18n/i18n.spec.ts
@@ -23,7 +23,7 @@ describe('theme: i18n', () => {
   describe('', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [AlainThemeModule.forRoot()],
+        imports: [AlainThemeModule],
         declarations: [TestComponent]
       });
       fixture = TestBed.createComponent(TestComponent);
@@ -68,7 +68,7 @@ describe('theme: i18n', () => {
 
   it('#interpolation', () => {
     TestBed.configureTestingModule({
-      imports: [AlainThemeModule.forRoot()],
+      imports: [AlainThemeModule],
       declarations: [TestComponent],
       providers: [{ provide: ALAIN_CONFIG, useValue: { themeI18n: { interpolation: ['#', '#'] } } as AlainConfig }]
     });
@@ -88,7 +88,7 @@ describe('theme: i18n', () => {
     it('should be working', fakeAsync(() => {
       TestBed.configureTestingModule({
         imports: [
-          AlainThemeModule.forRoot(),
+          AlainThemeModule,
           RouterTestingModule.withRoutes([
             {
               path: ':i18n',
@@ -112,7 +112,7 @@ describe('theme: i18n', () => {
     it('should be can not work', fakeAsync(() => {
       TestBed.configureTestingModule({
         imports: [
-          AlainThemeModule.forRoot(),
+          AlainThemeModule,
           RouterTestingModule.withRoutes([
             { path: ':invalid', component: TestComponent, canActivate: [alainI18nCanActivate] }
           ])
@@ -131,7 +131,7 @@ describe('theme: i18n', () => {
     it('should be working', fakeAsync(() => {
       TestBed.configureTestingModule({
         imports: [
-          AlainThemeModule.forRoot(),
+          AlainThemeModule,
           RouterTestingModule.withRoutes([
             { path: ':lang', component: TestComponent, canActivate: [alainI18nCanActivate] }
           ])

--- a/packages/theme/src/services/modal/modal.spec.ts
+++ b/packages/theme/src/services/modal/modal.spec.ts
@@ -14,7 +14,7 @@ describe('theme: ModalHelper', () => {
 
   beforeEach(() => {
     @NgModule({
-      imports: [CommonModule, NoopAnimationsModule, AlainThemeModule.forChild(), NzModalModule],
+      imports: [CommonModule, NoopAnimationsModule, AlainThemeModule, NzModalModule],
       declarations: [TestModalComponent, TestComponent]
     })
     class TestModule {}

--- a/packages/theme/src/services/rtl/rtl.service.spec.ts
+++ b/packages/theme/src/services/rtl/rtl.service.spec.ts
@@ -14,7 +14,7 @@ describe('Service: RTL', () => {
 
   beforeEach(() => {
     @NgModule({
-      imports: [CommonModule, AlainThemeModule.forChild()]
+      imports: [CommonModule, AlainThemeModule]
     })
     class TestModule {}
     const injector = TestBed.configureTestingModule({ imports: [TestModule] });

--- a/packages/theme/src/theme.module.ts
+++ b/packages/theme/src/theme.module.ts
@@ -1,12 +1,10 @@
 /* eslint-disable import/order */
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 // #region import
-
-const HELPERS = [ModalHelper, DrawerHelper];
 
 // pipes
 import { BellOutline, DeleteOutline, InboxOutline, PlusOutline } from '@ant-design/icons-angular/icons';
@@ -29,16 +27,13 @@ const PIPES = [DatePipe, KeysPipe, YNPipe, I18nPipe, HTMLPipe, URLPipe];
 
 // - zorro: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/components/icon/icons.ts
 
-import { DrawerHelper } from './services/drawer/drawer.helper';
-import { ModalHelper } from './services/modal/modal.helper';
 import { ALAIN_SETTING_KEYS } from './services/settings/settings.service';
 const ICONS = [BellOutline, DeleteOutline, PlusOutline, InboxOutline];
 
 // #endregion
 
 @NgModule({
-  imports: [CommonModule, RouterModule, OverlayModule, NzI18nModule],
-  declarations: PIPES,
+  imports: [CommonModule, RouterModule, OverlayModule, NzI18nModule, ...PIPES],
   providers: [
     {
       provide: ALAIN_SETTING_KEYS,
@@ -54,19 +49,5 @@ const ICONS = [BellOutline, DeleteOutline, PlusOutline, InboxOutline];
 export class AlainThemeModule {
   constructor(iconSrv: NzIconService) {
     iconSrv.addIcon(...ICONS);
-  }
-
-  static forRoot(): ModuleWithProviders<AlainThemeModule> {
-    return {
-      ngModule: AlainThemeModule,
-      providers: HELPERS
-    };
-  }
-
-  static forChild(): ModuleWithProviders<AlainThemeModule> {
-    return {
-      ngModule: AlainThemeModule,
-      providers: HELPERS
-    };
   }
 }

--- a/schematics/application/files/src/app/layout/layout.module.ts
+++ b/schematics/application/files/src/app/layout/layout.module.ts
@@ -48,7 +48,7 @@ const PASSPORT = [
     CommonModule,
     FormsModule,
     RouterModule,<% if (i18n) { %>
-    AlainThemeModule.forChild(),<% } %>
+    AlainThemeModule,<% } %>
     ThemeBtnModule,
     SettingDrawerModule,
     LayoutDefaultModule,

--- a/schematics/application/files/src/app/shared/shared.module.ts
+++ b/schematics/application/files/src/app/shared/shared.module.ts
@@ -28,7 +28,7 @@ const DIRECTIVES: Array<Type<void>> = [];
     FormsModule,
     RouterModule,
     ReactiveFormsModule,
-    AlainThemeModule.forChild(),
+    AlainThemeModule,
     DelonACLModule,<% if (form) { %>
     DelonFormModule,<% } %>
     ...SHARED_DELON_MODULES,

--- a/schematics/collection.json
+++ b/schematics/collection.json
@@ -7,8 +7,8 @@
       "aliases": ["alain-shell"]
     },
     "ng-update": {
-      "factory": "./ng-update/index#updateToV13",
-      "description": "Updates the NG-ALAIN to v13"
+      "factory": "./ng-update/index#updateToV17",
+      "description": "Just TEST"
     },
     "application": {
       "factory": "./application",

--- a/schematics/ng-update/index.ts
+++ b/schematics/ng-update/index.ts
@@ -14,7 +14,7 @@ export function updateToV17(): Rule {
 /** Post-update schematic to be called when update is finished. */
 export function postUpdate(context: SchematicContext, targetVersion: TargetVersion, hasFailures: boolean): void {
   context.logger.info('');
-  context.logger.info(`  ✓  Updated NG-ALAIN to ${targetVersion}`);
+  context.logger.info(`✓  Updated NG-ALAIN to ${targetVersion}`);
   context.logger.info('');
 
   if (hasFailures) {

--- a/schematics/ng-update/upgrade-rules/v17/autoRegisterFormWidgets.ts
+++ b/schematics/ng-update/upgrade-rules/v17/autoRegisterFormWidgets.ts
@@ -1,0 +1,45 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { insertImport, addSymbolToNgModuleMetadata } from '@schematics/angular/utility/ast-utils';
+import { Change, InsertChange } from '@schematics/angular/utility/change';
+
+import { DEFAULT_WORKSPACE_PATH, getSourceFile, readJSON, applyChanges, logWarn } from '../../../utils';
+
+export function autoRegisterFormWidgets(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const angularJson = readJSON(tree, DEFAULT_WORKSPACE_PATH);
+    const projectNames = Object.keys(angularJson.projects);
+    for (const name of projectNames) {
+      autoRegisterFormWidgetsRun(tree, name, angularJson.projects[name].sourceRoot, context);
+    }
+  };
+}
+
+function autoRegisterFormWidgetsRun(tree: Tree, name: string, sourceRoot: string, context: SchematicContext): void {
+  const modulePath = `${sourceRoot}/app/shared/json-schema/json-schema.module.ts`;
+  if (!tree.exists(modulePath)) return;
+
+  const list = [
+    { symbolName: 'AutoCompleteWidgetModule', fileName: '@delon/form/widgets/autocomplete' },
+    { symbolName: 'CascaderWidgetModule', fileName: '@delon/form/widgets/cascader' },
+    { symbolName: 'MentionWidgetModule', fileName: '@delon/form/widgets/mention' },
+    { symbolName: 'RateWidgetModule', fileName: '@delon/form/widgets/rate' },
+    { symbolName: 'SliderWidgetModule', fileName: '@delon/form/widgets/slider' },
+    { symbolName: 'TagWidgetModule', fileName: '@delon/form/widgets/tag' },
+    { symbolName: 'TimeWidgetModule', fileName: '@delon/form/widgets/time' },
+    { symbolName: 'TransferWidgetModule', fileName: '@delon/form/widgets/transfer' },
+    { symbolName: 'TreeSelectWidgetModule', fileName: '@delon/form/widgets/tree-select' },
+    { symbolName: 'UploadWidgetModule', fileName: '@delon/form/widgets/upload' }
+  ];
+  const source = getSourceFile(tree, modulePath);
+  const changes: Change[] = [];
+  for (const item of list) {
+    changes.push(insertImport(source, modulePath, item.symbolName, item.fileName) as InsertChange);
+    changes.push(...addSymbolToNgModuleMetadata(source, modulePath, 'imports', item.symbolName));
+  }
+  applyChanges(tree, modulePath, changes);
+
+  logWarn(
+    context,
+    `[@delon/form] Register all widgets in ${name} project, you can reduce package size by removing unnecessary parts`
+  );
+}

--- a/schematics/ng-update/upgrade-rules/v17/index.spec.ts
+++ b/schematics/ng-update/upgrade-rules/v17/index.spec.ts
@@ -49,4 +49,18 @@ describe('Schematic: ng-update: v17Rule', () => {
     expect(content).toContain(`import { UploadWidgetModule } from '@delon/form/widgets/upload';`);
     expect(content).toContain(`, UploadWidgetModule`);
   });
+
+  it('#removeAlainThemeModuleForRoot', async () => {
+    const globalConfigPath = '/projects/foo/src/app/global-config.module.ts';
+    tree.create(
+      globalConfigPath,
+      `
+    import { AlainThemeModule } from '@delon/theme';
+    const alainModules: any[] = [AlainThemeModule.forRoot(), DelonACLModule.forRoot()];
+    `
+    );
+    await runMigration();
+    const content = tree.readContent(globalConfigPath);
+    expect(content).not.toContain(`AlainThemeModule.forRoot()`);
+  });
 });

--- a/schematics/ng-update/upgrade-rules/v17/index.ts
+++ b/schematics/ng-update/upgrade-rules/v17/index.ts
@@ -1,79 +1,35 @@
 import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { insertImport, addSymbolToNgModuleMetadata } from '@schematics/angular/utility/ast-utils';
-import { Change, InsertChange } from '@schematics/angular/utility/change';
-import * as colors from 'ansi-colors';
 
-import { DEFAULT_WORKSPACE_PATH, getSourceFile, logStart, readJSON, applyChanges } from '../../../utils';
+import { autoRegisterFormWidgets } from './autoRegisterFormWidgets';
+import { removeAlainThemeModuleForRoot } from './removeAlainThemeModuleForRoot';
+import { logFinished, logInfo, logWarn } from '../../../utils';
 import { UpgradeMainVersions } from '../../../utils/versions';
 
 function qr(): Rule {
   return (_: Tree, context: SchematicContext) => {
-    context.logger.info(
-      colors.yellow(
-        ` [qr] Will be removed in 18.0.0, please use [nz-qrcode](https://ng.ant.design/components/qr-code) instead.`
-      )
+    logWarn(
+      context,
+      `[qr] Will be removed in 18.0.0, please use [nz-qrcode](https://ng.ant.design/components/qr-code) instead.`
     );
   };
-}
-
-function autoRegisterFormWidgets(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const angularJson = readJSON(tree, DEFAULT_WORKSPACE_PATH);
-    const projectNames = Object.keys(angularJson.projects);
-    for (const name of projectNames) {
-      autoRegisterFormWidgetsRun(tree, name, angularJson.projects[name].sourceRoot, context);
-    }
-  };
-}
-
-function autoRegisterFormWidgetsRun(tree: Tree, name: string, sourceRoot: string, context: SchematicContext): void {
-  const modulePath = `${sourceRoot}/app/shared/json-schema/json-schema.module.ts`;
-  if (!tree.exists(modulePath)) return;
-
-  const list = [
-    { symbolName: 'AutoCompleteWidgetModule', fileName: '@delon/form/widgets/autocomplete' },
-    { symbolName: 'CascaderWidgetModule', fileName: '@delon/form/widgets/cascader' },
-    { symbolName: 'MentionWidgetModule', fileName: '@delon/form/widgets/mention' },
-    { symbolName: 'RateWidgetModule', fileName: '@delon/form/widgets/rate' },
-    { symbolName: 'SliderWidgetModule', fileName: '@delon/form/widgets/slider' },
-    { symbolName: 'TagWidgetModule', fileName: '@delon/form/widgets/tag' },
-    { symbolName: 'TimeWidgetModule', fileName: '@delon/form/widgets/time' },
-    { symbolName: 'TransferWidgetModule', fileName: '@delon/form/widgets/transfer' },
-    { symbolName: 'TreeSelectWidgetModule', fileName: '@delon/form/widgets/tree-select' },
-    { symbolName: 'UploadWidgetModule', fileName: '@delon/form/widgets/upload' }
-  ];
-  const source = getSourceFile(tree, modulePath);
-  const changes: Change[] = [];
-  for (const item of list) {
-    changes.push(insertImport(source, modulePath, item.symbolName, item.fileName) as InsertChange);
-    changes.push(...addSymbolToNgModuleMetadata(source, modulePath, 'imports', item.symbolName));
-  }
-  applyChanges(tree, modulePath, changes);
-
-  context.logger.info(
-    colors.yellow(
-      ` [@delon/form] Register all widgets in ${name} project, you can reduce package size by removing unnecessary parts`
-    )
-  );
 }
 
 function finished(): Rule {
   return (_tree: Tree, context: SchematicContext) => {
     context.addTask(new NodePackageInstallTask());
 
-    context.logger.info(
-      colors.green(
-        `  ✓ Congratulations, Abort more detail please refer to upgrade guide https://github.com/ng-alain/ng-alain/issues/2390`
-      )
+    logFinished(
+      context,
+      `Congratulations, Abort more detail please refer to upgrade guide https://github.com/ng-alain/ng-alain/issues/2390`
     );
   };
 }
 
 export function v17Rule(): Rule {
   return async (tree: Tree, context: SchematicContext) => {
-    logStart(context, `Upgrade @delon/* version number`);
     UpgradeMainVersions(tree);
-    return chain([autoRegisterFormWidgets(), qr(), finished()]);
+    logInfo(context, `Upgrade dependency version number`);
+    return chain([removeAlainThemeModuleForRoot(), autoRegisterFormWidgets(), qr(), finished()]);
   };
 }

--- a/schematics/ng-update/upgrade-rules/v17/removeAlainThemeModuleForRoot.ts
+++ b/schematics/ng-update/upgrade-rules/v17/removeAlainThemeModuleForRoot.ts
@@ -1,0 +1,40 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+import { DEFAULT_WORKSPACE_PATH, logInfo, readJSON } from '../../../utils';
+
+export function removeAlainThemeModuleForRoot(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const angularJson = readJSON(tree, DEFAULT_WORKSPACE_PATH);
+    const projectNames = Object.keys(angularJson.projects);
+    for (const name of projectNames) {
+      removeForRoot(tree, name, angularJson.projects[name].sourceRoot, context);
+      removeForChild(tree, name, angularJson.projects[name].sourceRoot, context);
+    }
+  };
+}
+
+function removeForRoot(tree: Tree, name: string, sourceRoot: string, context: SchematicContext): void {
+  const modulePath = `${sourceRoot}/app/global-config.module.ts`;
+  if (!tree.exists(modulePath)) return;
+
+  const forRoot = 'AlainThemeModule.forRoot()';
+  const content = tree.readText(modulePath).replace(`${forRoot},`, '');
+  tree.overwrite(modulePath, content);
+
+  logInfo(context, `Remove ${forRoot} in ${name} project`);
+}
+
+function removeForChild(tree: Tree, name: string, _: string, context: SchematicContext): void {
+  const forChild = 'AlainThemeModule.forChild()';
+
+  tree.visit((path, entry) => {
+    if (!entry || !path.endsWith('.ts')) return;
+
+    const content = tree.readText(path);
+    if (!content.includes(forChild)) return;
+
+    tree.overwrite(path, content.replace(forChild, 'AlainThemeModule'));
+  });
+
+  logInfo(context, `Remove ${forChild} in ${name} project`);
+}

--- a/schematics/utils/log.ts
+++ b/schematics/utils/log.ts
@@ -2,13 +2,17 @@ import { SchematicContext } from '@angular-devkit/schematics';
 import * as colors from 'ansi-colors';
 
 export function logStart(context: SchematicContext, message: string): void {
-  context.logger.info(`  ${colors.green('✓')} ${message}`);
+  context.logger.info(`${colors.green('✓')} ${message}`);
 }
 
 export function logInfo(context: SchematicContext, message: string): void {
-  context.logger.info(`    ${colors.green('✓')} ${message}`);
+  context.logger.info(`  ${colors.green('✓')} ${message}`);
 }
 
 export function logWarn(context: SchematicContext, message: string): void {
-  context.logger.info(`    ${colors.yellow('✓')} ${message}`);
+  context.logger.info(`  ${colors.yellow('⚠')} ${message}`);
+}
+
+export function logFinished(context: SchematicContext, message: string): void {
+  context.logger.info(`${colors.green(`✓ ${message}`)}`);
 }

--- a/src/app/core/code/files/app.module.ts
+++ b/src/app/core/code/files/app.module.ts
@@ -45,7 +45,7 @@ imports: [
     BrowserAnimationsModule,
     RouterModule.forRoot([]),
     DemoNgZorroAntdModule,
-    AlainThemeModule.forRoot(),
+    AlainThemeModule,
     DemoDelonABCModule,
     DemoDelonChartModule,
     DelonACLModule.forRoot(),

--- a/src/app/core/code/files/global-config.module.ts
+++ b/src/app/core/code/files/global-config.module.ts
@@ -1,6 +1,5 @@
 export default `import { ModuleWithProviders, NgModule } from '@angular/core';
 import { DelonMockModule } from '@delon/mock';
-import { AlainThemeModule } from '@delon/theme';
 import { AlainConfig, ALAIN_CONFIG, AlainConfigService } from '@delon/util/config';
 
 // Please refer to: https://ng-alain.com/docs/global-config
@@ -11,7 +10,7 @@ import * as MOCKDATA from '../../_mock';
 
 const alainConfig: AlainConfig = { };
 
-const alainModules = [AlainThemeModule.forRoot(), DelonACLModule.forRoot(), DelonMockModule.forRoot({ data: MOCKDATA })];
+const alainModules = [DelonACLModule.forRoot(), DelonMockModule.forRoot({ data: MOCKDATA })];
 const alainProvides = [{ provide: ALAIN_CONFIG, useValue: alainConfig }];
 
 // #region reuse-tab

--- a/src/app/global-config.module.ts
+++ b/src/app/global-config.module.ts
@@ -3,7 +3,6 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { DelonACLModule } from '@delon/acl';
 import { DelonMockModule } from '@delon/mock';
-import { AlainThemeModule } from '@delon/theme';
 import { AlainConfig, ALAIN_CONFIG } from '@delon/util/config';
 
 // Please refer to: https://ng-alain.com/docs/global-config
@@ -73,7 +72,7 @@ const zorroProvides = [provideNzConfig(ngZorroConfig)];
 // #endregion
 
 @NgModule({
-  imports: [AlainThemeModule.forRoot(), DelonACLModule.forRoot(), DelonMockModule.forRoot({ data: MOCKDATA })]
+  imports: [DelonACLModule.forRoot(), DelonMockModule.forRoot({ data: MOCKDATA })]
 })
 export class GlobalConfigModule {
   static forRoot(): ModuleWithProviders<GlobalConfigModule> {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -50,7 +50,7 @@ const THIRDS = [HighlightJsModule, GithubButtonModule, NgxTinymceModule, ColorSk
     FormsModule,
     RouterModule,
     ReactiveFormsModule,
-    AlainThemeModule.forChild(),
+    AlainThemeModule,
     DelonACLModule,
     DelonFormModule,
     DelonCacheModule,


### PR DESCRIPTION
BREAKING CHANGE: 由于早期 ModalHelper 和 DrawerHelper 采用的 providedIn 非 root，故才需要。移除后 `global-config.module.ts` 也将不需要 `AlainThemeModule.forRoot()`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
