### PR TITLE
perf(theme:preloader): fix loading order issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -38,3 +38,5 @@ node_modules/
 
 # yarn v2
 .yarn
+
+**/src/index.html

--- a/packages/theme/public_api.ts
+++ b/packages/theme/public_api.ts
@@ -1,4 +1,4 @@
-export { preloaderFinished } from './src/services/preloader/preloader';
+export * from './src/services/preloader/preloader';
 export * from './src/services/menu/interface';
 export * from './src/services/menu/menu.service';
 export * from './src/services/settings/types';

--- a/packages/theme/src/services/preloader/preloader.ts
+++ b/packages/theme/src/services/preloader/preloader.ts
@@ -1,12 +1,36 @@
+import { DOCUMENT } from '@angular/common';
+import { inject } from '@angular/core';
+
 import type { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+export function stepPreloader(): () => void {
+  const doc: Document = inject(DOCUMENT);
+  const body = doc.querySelector('body')!;
+  body.style.overflow = 'hidden';
+  let done = false;
+
+  return () => {
+    if (done) return;
+
+    done = true;
+    const preloader = doc.querySelector<HTMLElement>('.preloader');
+    if (preloader == null) return;
+
+    preloader.addEventListener('transitionend', () => {
+      preloader.className = 'preloader-hidden';
+    });
+    preloader.className += ' preloader-hidden-add preloader-hidden-add-active';
+    const body = doc.querySelector('body')!;
+    body.style.overflow = '';
+  };
+}
 
 export function preloaderFinished(): void {
   const body = document.querySelector('body')!;
-  const preloader = document.querySelector('.preloader')!;
-
   body.style.overflow = 'hidden';
 
   function remove(): void {
+    const preloader = document.querySelector('.preloader')!;
     // preloader value null when running --hmr
     if (!preloader) return;
     preloader.addEventListener('transitionend', () => {
@@ -20,6 +44,6 @@ export function preloaderFinished(): void {
     setTimeout(() => {
       remove();
       body.style.overflow = '';
-    }, 100);
+    }, 25);
   };
 }

--- a/packages/theme/src/services/preloader/preloader.ts
+++ b/packages/theme/src/services/preloader/preloader.ts
@@ -1,8 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { inject } from '@angular/core';
 
-import type { NzSafeAny } from 'ng-zorro-antd/core/types';
-
 export function stepPreloader(): () => void {
   const doc: Document = inject(DOCUMENT);
   const body = doc.querySelector('body')!;
@@ -16,34 +14,12 @@ export function stepPreloader(): () => void {
     const preloader = doc.querySelector<HTMLElement>('.preloader');
     if (preloader == null) return;
 
+    const CLS = 'preloader-hidden';
     preloader.addEventListener('transitionend', () => {
-      preloader.className = 'preloader-hidden';
+      preloader.className = CLS;
     });
-    preloader.className += ' preloader-hidden-add preloader-hidden-add-active';
-    const body = doc.querySelector('body')!;
+    preloader.className += ` ${CLS}-add ${CLS}-add-active`;
+    const body = doc.querySelector<HTMLBodyElement>('body')!;
     body.style.overflow = '';
-  };
-}
-
-export function preloaderFinished(): void {
-  const body = document.querySelector('body')!;
-  body.style.overflow = 'hidden';
-
-  function remove(): void {
-    const preloader = document.querySelector('.preloader')!;
-    // preloader value null when running --hmr
-    if (!preloader) return;
-    preloader.addEventListener('transitionend', () => {
-      preloader.className = 'preloader-hidden';
-    });
-
-    preloader.className += ' preloader-hidden-add preloader-hidden-add-active';
-  }
-
-  (window as NzSafeAny).appBootstrap = () => {
-    setTimeout(() => {
-      remove();
-      body.style.overflow = '';
-    }, 25);
   };
 }

--- a/schematics/ng-update/upgrade-rules/v17/index.spec.ts
+++ b/schematics/ng-update/upgrade-rules/v17/index.spec.ts
@@ -1,5 +1,6 @@
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 
+import { tryAddFile } from '../../../utils';
 import { createAlainApp, migrationCollection } from '../../../utils/testing';
 
 describe('Schematic: ng-update: v17Rule', () => {
@@ -52,7 +53,8 @@ describe('Schematic: ng-update: v17Rule', () => {
 
   it('#removeForRoot', async () => {
     const globalConfigPath = '/projects/foo/src/app/global-config.module.ts';
-    tree.create(
+    tryAddFile(
+      tree,
       globalConfigPath,
       `
     import { AlainThemeModule } from '@delon/theme';
@@ -67,9 +69,57 @@ describe('Schematic: ng-update: v17Rule', () => {
 
   it('#replaceProvideAlainConfig', async () => {
     const globalConfigPath = '/projects/foo/src/app/global-config.module.ts';
-    tree.create(globalConfigPath, `const alainProvides = [{ provide: ALAIN_CONFIG, useValue: alainConfig }];`);
+    tryAddFile(tree, globalConfigPath, `const alainProvides = [{ provide: ALAIN_CONFIG, useValue: alainConfig }];`);
     await runMigration();
     const content = tree.readContent(globalConfigPath);
     expect(content).toContain(`provideAlainConfig(alainConfig)`);
+  });
+
+  it('#preloader', async () => {
+    const appCompPath = '/projects/foo/src/app/app.component.ts';
+    tryAddFile(
+      tree,
+      appCompPath,
+      `import { Component, ElementRef, OnInit, Renderer2 } from '@angular/core';
+import { NavigationEnd, NavigationError, RouteConfigLoadStart, Router } from '@angular/router';
+import { TitleService, VERSION as VERSION_ALAIN } from '@delon/theme';
+import { environment } from '@env/environment';
+import { NzModalService } from 'ng-zorro-antd/modal';
+import { VERSION as VERSION_ZORRO } from 'ng-zorro-antd/version';
+
+@Component({
+  selector: 'app-root',
+})
+export class AppComponent implements OnInit {
+  constructor(
+    el: ElementRef,
+    renderer: Renderer2,
+    private router: Router,
+    private titleSrv: TitleService,
+    private modalSrv: NzModalService
+  ) {
+    renderer.setAttribute(el.nativeElement, 'ng-alain-version', VERSION_ALAIN.full);
+    renderer.setAttribute(el.nativeElement, 'ng-zorro-version', VERSION_ZORRO.full);
+  }
+
+  ngOnInit(): void {
+    let configLoad = false;
+    this.router.events.subscribe(ev => {
+      if (ev instanceof RouteConfigLoadStart) {
+        configLoad = true;
+      }
+      if (ev instanceof NavigationEnd) {
+        this.titleSrv.setTitle();
+        this.modalSrv.closeAll();
+      }
+    });
+  }
+}
+`
+    );
+    await runMigration();
+    const content = tree.readContent(appCompPath);
+    expect(content).toContain(`const done = stepPreloader();`);
+    expect(content).toContain(`done();`);
   });
 });

--- a/schematics/ng-update/upgrade-rules/v17/index.spec.ts
+++ b/schematics/ng-update/upgrade-rules/v17/index.spec.ts
@@ -119,7 +119,7 @@ export class AppComponent implements OnInit {
     );
     await runMigration();
     const content = tree.readContent(appCompPath);
-    expect(content).toContain(`const done = stepPreloader();`);
-    expect(content).toContain(`done();`);
+    expect(content).toContain(`private donePreloader = stepPreloader();`);
+    expect(content).toContain(`this.donePreloader();`);
   });
 });

--- a/schematics/ng-update/upgrade-rules/v17/index.ts
+++ b/schematics/ng-update/upgrade-rules/v17/index.ts
@@ -2,6 +2,7 @@ import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics'
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
 import { autoRegisterFormWidgets } from './autoRegisterFormWidgets';
+import { updatePreloader } from './preloader';
 import { removeForRoot } from './removeForRoot';
 import { replaceProvideConfig } from './replaceProvideConfig';
 import { logFinished, logInfo, logWarn } from '../../../utils';
@@ -31,6 +32,13 @@ export function v17Rule(): Rule {
   return async (tree: Tree, context: SchematicContext) => {
     UpgradeMainVersions(tree);
     logInfo(context, `Upgrade dependency version number`);
-    return chain([removeForRoot(), autoRegisterFormWidgets(), replaceProvideConfig(), qr(), finished()]);
+    return chain([
+      removeForRoot(),
+      autoRegisterFormWidgets(),
+      replaceProvideConfig(),
+      updatePreloader(),
+      qr(),
+      finished()
+    ]);
   };
 }

--- a/schematics/ng-update/upgrade-rules/v17/preloader.ts
+++ b/schematics/ng-update/upgrade-rules/v17/preloader.ts
@@ -1,0 +1,55 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+import { DEFAULT_WORKSPACE_PATH, logWarn, readJSON } from '../../../utils';
+
+export function updatePreloader(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    addESLintIgnore(tree);
+
+    const angularJson = readJSON(tree, DEFAULT_WORKSPACE_PATH);
+    const projectNames = Object.keys(angularJson.projects);
+    for (const name of projectNames) {
+      run(tree, name, angularJson.projects[name].sourceRoot, context);
+    }
+  };
+}
+
+function addESLintIgnore(tree: Tree): void {
+  const filePath = '/.eslintignore';
+  if (!tree.exists(filePath)) return;
+  const content = tree.readText(filePath);
+  tree.overwrite(filePath, `${content}\n**/src/index.html`);
+}
+
+function run(tree: Tree, name: string, sourceRoot: string, context: SchematicContext): void {
+  // main.ts
+  const mainPath = `${sourceRoot}/main.ts`;
+  if (!tree.exists(mainPath)) return;
+
+  let mainContent = tree.readText(mainPath);
+  ['preloaderFinished();'].forEach(item => {
+    if (mainContent.includes(item)) mainContent = mainContent.replace(item, '');
+  });
+  tree.overwrite(mainPath, mainContent);
+
+  // app
+  const appPath = `${sourceRoot}/app/app.component.ts`;
+  if (!tree.exists(appPath)) return;
+  const appContent = tree.readText(appPath);
+  const appContentLines = appContent.split('\n');
+  const importIndex = appContentLines.findIndex(line => line.includes(', VERSION as VERSION_ALAIN'));
+  const eventIndex = appContentLines.findIndex(line => line.includes('this.router.events.subscribe('));
+  const eventEndIndex = appContentLines.findIndex(line => line.includes('if (ev instanceof NavigationEnd) {'));
+  if (importIndex === -1 || eventIndex === -1 || eventEndIndex === -1) return;
+
+  appContentLines[importIndex] = appContentLines[importIndex].replace(
+    ', VERSION as VERSION_ALAIN',
+    ', VERSION as VERSION_ALAIN, stepPreloader'
+  );
+  appContentLines.splice(eventIndex, 0, 'const done = stepPreloader();');
+  appContentLines.splice(eventEndIndex + 2, 0, 'done();');
+
+  tree.overwrite(appPath, appContentLines.join('\n'));
+
+  logWarn(context, `Upgrade preloader in ${name} project`);
+}

--- a/schematics/ng-update/upgrade-rules/v17/removeForRoot.ts
+++ b/schematics/ng-update/upgrade-rules/v17/removeForRoot.ts
@@ -26,11 +26,11 @@ function removeAlainThemeForRoot(tree: Tree, name: string, sourceRoot: string, c
   logInfo(context, `Remove ${forRoot} in ${name} project`);
 }
 
-function removeAlainThemeForChild(tree: Tree, name: string, _: string, context: SchematicContext): void {
+function removeAlainThemeForChild(tree: Tree, name: string, sourceRoot: string, context: SchematicContext): void {
   const forChild = 'AlainThemeModule.forChild()';
 
   tree.visit((path, entry) => {
-    if (!entry || !path.endsWith('.ts')) return;
+    if (!entry || !path.endsWith('.ts') || !path.startsWith(sourceRoot)) return;
 
     const content = tree.readText(path);
     if (!content.includes(forChild)) return;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
 import { Component, ElementRef, HostBinding, Inject, Renderer2 } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 
-import { ALAIN_I18N_TOKEN, DrawerHelper, TitleService, VERSION as VERSION_ALAIN } from '@delon/theme';
+import { ALAIN_I18N_TOKEN, DrawerHelper, TitleService, VERSION as VERSION_ALAIN, stepPreloader } from '@delon/theme';
 import { VERSION as VERSION_ZORRO } from 'ng-zorro-antd/version';
 
 import { I18NService, MetaService, MobileService } from '@core';
@@ -37,8 +37,12 @@ export class AppComponent {
       mobileSrv.next(this.isMobile);
     });
 
+    const done = stepPreloader();
+
     router.events.subscribe(evt => {
       if (!(evt instanceof NavigationEnd)) return;
+
+      done();
 
       dh.closeAll();
 

--- a/src/index.html
+++ b/src/index.html
@@ -46,13 +46,16 @@
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="./assets/img/logo-color.png">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#1976d2" />
+  <style>
+    .preloader {position:absolute;top:0;right:0;bottom:0;left:0;display:flex;align-items:center;justify-content:center;font-size:14px;font-family:Helvetica;}
+    .preloader-hidden-add{display:block;opacity:1}.preloader-hidden-add-active{opacity:0}.preloader-hidden{display:none}
+  </style>
 </head>
 
 <body ontouchstart>
   <noscript>Please enable JavaScript to continue using this application.</noscript>
-  <app-root>
-    <div style="position:absolute;top:0;right:0;bottom:0;left:0;display:flex;align-items:center;justify-content:center;font-size:14px;font-family:Helvetica;">loading...</div>
-  </app-root>
+  <app-root></app-root>
+  <div class="preloader">Loading...</div>
   <div id="_ie" style="position:absolute;top:0;right:0;bottom:0;left:0;z-index:9999;display:none;padding-top:32px;font-size:22px;text-align:center;background:#fff;">
     Your browser is not supported for NG-ALAIN document site
   </div>
@@ -66,7 +69,6 @@
     if (!!navigator.userAgent.match(/Trident/g) || !!navigator.userAgent.match(/MSIE/g)) {
       document.querySelector('#_ie').style.display = 'block';
     }
-
   </script>
   <script>
     if (location.host !== 'ng-alain-doc.surge.sh') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,11 @@
-import { enableProdMode, ViewEncapsulation } from '@angular/core';
+import { ViewEncapsulation } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import type { NzSafeAny } from 'ng-zorro-antd/core/types';
-
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule, {
     defaultEncapsulation: ViewEncapsulation.None,
     preserveWhitespaces: false
-  })
-  .then(res => {
-    if ((window as NzSafeAny).appBootstrap) {
-      (window as NzSafeAny).appBootstrap();
-    }
-    return res;
   })
   .catch(err => console.error(err));


### PR DESCRIPTION
BREAKING CHANGE: 之前提供的 `preloaderFinished` 并不能解决当首次加载的路由是懒加载时中间存在空白问题

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
