### PR TITLE
refactor(abc:cell): widget `data` type changed to CellTextResult

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -155,6 +155,7 @@
             "include": [
               "./test.ts",
               // "**/st.spec.ts"
+              // "**/st/**/*.spec.ts"
               "**/*.spec.ts"
             ]
           }

--- a/packages/abc/cell/cell-host.directive.ts
+++ b/packages/abc/cell/cell-host.directive.ts
@@ -3,7 +3,7 @@ import { Directive, Input, OnInit, Type, ViewContainerRef, inject } from '@angul
 import { warn } from '@delon/util/other';
 
 import { CellService } from './cell.service';
-import { CellWidgetData } from './cell.types';
+import { CellTextResult } from './cell.types';
 
 @Directive({
   selector: '[cell-widget-host]',
@@ -13,7 +13,7 @@ export class CellHostDirective implements OnInit {
   private readonly srv = inject(CellService);
   private readonly viewContainerRef = inject(ViewContainerRef);
 
-  @Input() data!: CellWidgetData;
+  @Input() data!: CellTextResult;
 
   ngOnInit(): void {
     const widget = this.data.options!.widget!;
@@ -27,6 +27,6 @@ export class CellHostDirective implements OnInit {
 
     this.viewContainerRef.clear();
     const componentRef = this.viewContainerRef.createComponent(componentType);
-    (componentRef.instance as { data: CellWidgetData }).data = this.data;
+    (componentRef.instance as { data: CellTextResult }).data = this.data;
   }
 }

--- a/packages/abc/cell/cell.component.ts
+++ b/packages/abc/cell/cell.component.ts
@@ -59,10 +59,12 @@ import type { CellDefaultText, CellOptions, CellTextResult, CellValue } from './
           </nz-tag>
         }
         @case ('badge') {
-          <nz-badge [nzStatus]="res?.result?.color" [nzText]="_text" />
+          <nz-badge [nzStatus]="res?.result?.color" nzText="{{ _text }}" />
         }
         @case ('widget') {
-          <ng-template cell-widget-host [data]="res" />
+          @if (res != null) {
+            <ng-template cell-widget-host [data]="res" />
+          }
         }
         @case ('img') {
           @for (i of $any(_text); track $index) {

--- a/packages/abc/cell/cell.component.ts
+++ b/packages/abc/cell/cell.component.ts
@@ -33,7 +33,7 @@ import { NzTooltipDirective } from 'ng-zorro-antd/tooltip';
 
 import { CellHostDirective } from './cell-host.directive';
 import { CellService } from './cell.service';
-import type { CellDefaultText, CellOptions, CellTextResult, CellValue, CellWidgetData } from './cell.types';
+import type { CellDefaultText, CellOptions, CellTextResult, CellValue } from './cell.types';
 
 @Component({
   selector: 'cell, [cell]',
@@ -59,10 +59,10 @@ import type { CellDefaultText, CellOptions, CellTextResult, CellValue, CellWidge
           </nz-tag>
         }
         @case ('badge') {
-          <nz-badge [nzStatus]="res?.result?.color" nzText="{{ _text }}" />
+          <nz-badge [nzStatus]="res?.result?.color" [nzText]="_text" />
         }
         @case ('widget') {
-          <ng-template cell-widget-host [data]="hostData" />
+          <ng-template cell-widget-host [data]="res" />
         }
         @case ('img') {
           @for (i of $any(_text); track $index) {
@@ -153,13 +153,6 @@ export class CellComponent implements OnChanges, OnDestroy {
 
   get isText(): boolean {
     return this.res?.safeHtml === 'text';
-  }
-
-  get hostData(): CellWidgetData {
-    return {
-      value: this.value,
-      options: this.srv.fixOptions(this.options)
-    };
   }
 
   private updateValue(): void {

--- a/packages/abc/cell/cell.spec.ts
+++ b/packages/abc/cell/cell.spec.ts
@@ -15,7 +15,7 @@ import { NzTooltipDirective } from 'ng-zorro-antd/tooltip';
 import { CellComponent } from './cell.component';
 import { CellModule } from './cell.module';
 import { CellService } from './cell.service';
-import { CellFuValue, CellOptions, CellWidgetData } from './cell.types';
+import { CellFuValue, CellOptions, CellTextResult } from './cell.types';
 import { provideCellWidgets } from './provide';
 
 const DATE = new Date(2022, 0, 1, 1, 2, 3);
@@ -354,12 +354,12 @@ describe('abc: cell', () => {
 });
 
 @Component({
-  template: `{{ data.value }}-{{ data.options.widget.data }}`
+  template: `{{ data.result.text }}-{{ data.options.widget.data }}`
 })
 class TestWidget {
   static readonly KEY = 'test';
 
-  data!: CellWidgetData;
+  data!: CellTextResult;
 }
 
 @Component({

--- a/packages/abc/cell/cell.types.ts
+++ b/packages/abc/cell/cell.types.ts
@@ -297,11 +297,6 @@ export interface CellDefaultText {
   condition?: unknown;
 }
 
-export interface CellWidgetData {
-  value?: unknown;
-  options?: CellOptions;
-}
-
 export interface CellWidgetInstance {
-  readonly data: CellWidgetData;
+  readonly data: CellTextResult;
 }

--- a/packages/abc/cell/index.en-US.md
+++ b/packages/abc/cell/index.en-US.md
@@ -67,25 +67,27 @@ Cell formatting is supported for multiple data types, and supports widget mode.
 Just implement the `CellWidgetInstance` interface, for example:
 
 ```ts
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import type { CellWidgetData, CellWidgetInstance } from '@delon/abc/cell';
+import type { CellTextResult, CellWidgetInstance } from '@delon/abc/cell';
 import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 @Component({
   selector: 'cell-widget-test',
-  template: ` <img nz-tooltip nzTooltipTitle="Client it" [src]="data.value" class="img" style="cursor: pointer" /> `,
+  template: `<img nz-tooltip nzTooltipTitle="Client it" [src]="data.result.text" class="img" style="cursor: pointer" /> `,
   host: {
     '(click)': 'show()'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [ NzToolTipModule ]
 })
 export class CellTestWidget implements CellWidgetInstance {
+  private readonly msg = inject(NzMessageService);
   static readonly KEY = 'test';
 
-  readonly data!: CellWidgetData;
-
-  constructor(private msg: NzMessageService) {}
+  readonly data!: CellTextResult;
 
   show(): void {
     this.msg.info(`click`);

--- a/packages/abc/cell/index.zh-CN.md
+++ b/packages/abc/cell/index.zh-CN.md
@@ -67,25 +67,27 @@ module: import { CellModule } from '@delon/abc/cell';
 实现 `CellWidgetInstance` 接口即可，例如：
 
 ```ts
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import type { CellWidgetData, CellWidgetInstance } from '@delon/abc/cell';
+import type { CellTextResult, CellWidgetInstance } from '@delon/abc/cell';
 import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 @Component({
   selector: 'cell-widget-test',
-  template: ` <img nz-tooltip nzTooltipTitle="Client it" [src]="data.value" class="img" style="cursor: pointer" /> `,
+  template: `<img nz-tooltip nzTooltipTitle="Client it" [src]="data.result.text" class="img" style="cursor: pointer" /> `,
   host: {
     '(click)': 'show()'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [ NzToolTipModule ]
 })
 export class CellTestWidget implements CellWidgetInstance {
+  private readonly msg = inject(NzMessageService);
   static readonly KEY = 'test';
 
-  readonly data!: CellWidgetData;
-
-  constructor(private msg: NzMessageService) {}
+  readonly data!: CellTextResult;
 
   show(): void {
     this.msg.info(`click`);

--- a/src/app/shared/cell-widget/test.ts
+++ b/src/app/shared/cell-widget/test.ts
@@ -1,12 +1,12 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import type { CellWidgetData, CellWidgetInstance } from '@delon/abc/cell';
+import type { CellTextResult, CellWidgetInstance } from '@delon/abc/cell';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 @Component({
   selector: 'cell-widget-test',
-  template: ` <img nz-tooltip nzTooltipTitle="Client it" [src]="data.value" class="img" style="cursor: pointer" /> `,
+  template: `<img nz-tooltip nzTooltipTitle="Client it" [src]="data.result.text" class="img" style="cursor: pointer" /> `,
   host: {
     '(click)': 'show()'
   },
@@ -15,11 +15,10 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   imports: [ NzToolTipModule ]
 })
 export class CellTestWidget implements CellWidgetInstance {
+  private readonly msg = inject(NzMessageService);
   static readonly KEY = 'test';
 
-  readonly data!: CellWidgetData;
-
-  constructor(private msg: NzMessageService) {}
+  readonly data!: CellTextResult;
 
   show(): void {
     this.msg.info(`click`);


### PR DESCRIPTION
Breaking Changes:
为了保持数据处理结果的统一性，将小部件的 `data` 类型由原来的 `CellWidgetData` 变更为 `CellTextResult` 以此来保证数据为处理后的结果。

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
