### PR TITLE
refactor: Improve URL query parameter handling for correct concatenat…

### DIFF
--- a/packages/abc/lodop/lodop.service.ts
+++ b/packages/abc/lodop/lodop.service.ts
@@ -86,10 +86,18 @@ export class LodopService implements OnDestroy {
     if (!this._lodop) throw new Error(`请务必先调用 lodop 获取对象`);
   }
 
+  private requestUrl(): string {
+    const urlObj = new URL(this.cog.url!);
+    const params = new URLSearchParams(urlObj.search);
+    params.set('name', this.cog.name!);
+    urlObj.search = params.toString();
+    return urlObj.toString();
+  }
+
   private request(): void {
     this.pending = true;
 
-    const url = `${this.cog.url}?name=${this.cog.name}`;
+    const url = this.requestUrl();
     let checkMaxCount = this.cog.checkMaxCount as number;
     const onResolve = (status: NzSafeAny, error?: NzSafeAny): void => {
       this._init.next({
@@ -160,7 +168,7 @@ export class LodopService implements OnDestroy {
         try {
           const fakeFn = new Function(`return [${res[2]}]`);
           arr = fakeFn();
-        } catch {}
+        } catch { }
 
         if (arr != null && Array.isArray(arr) && contextObj) {
           for (let i = 0; i < arr.length; i++) {

--- a/packages/abc/lodop/lodop.service.ts
+++ b/packages/abc/lodop/lodop.service.ts
@@ -87,9 +87,15 @@ export class LodopService implements OnDestroy {
   }
 
   private requestUrl(): string {
-    const urlObj = new URL(this.cog.url!);
+    if (!this.cog.url) {
+      throw new Error('URL is not defined');
+    }
+    if (!this.cog.name) {
+      throw new Error('Name is not defined');
+    }
+    const urlObj = new URL(this.cog.url);
     const params = new URLSearchParams(urlObj.search);
-    params.set('name', this.cog.name!);
+    params.set('name', this.cog.name);
     urlObj.search = params.toString();
     return urlObj.toString();
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current URL handling does not correctly concatenate query parameters if the URL already contains existing parameters.
exp: 
``` 
in app.config.ts:
"lodop": {
    "companyName": "xxxxxx",
    "url": "https://print.xxx.com:8443/CLodopfuncs.js?AOListCount=500"
}
```
lodop.service.ts#request:
https://print.xxx.com:8443/CLodopfuncs.js?AOListCount=100?name=CLodop



## What is the new behavior?
The URL handling has been refactored to correctly concatenate query parameters even if the URL already contains existing parameters. The new implementation also ensures proper encoding of the query parameters.
exp: 
https://print.xxx.com:8443/CLodopfuncs.js?AOListCount=100&name=CLodop

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
