### PR TITLE
feat(abc:st): add delay property to support delayed rendering

### DIFF
--- a/packages/abc/st/index.en-US.md
+++ b/packages/abc/st/index.en-US.md
@@ -66,6 +66,7 @@ When an exception is thrown when parsing column data, *INVALID DATA* will be for
 | `[loading]` | Loading status of table, when specifying `null` is controlled by st | `boolean | null` | `null` | - |
 | `[loadingIndicator]` | The spinning indicator | `TemplateRef<void>` | - | ✅ |
 | `[loadingDelay]` | Specifies a delay in milliseconds for loading state (prevent flush) | `number` | `0` | ✅ |
+| [delay] | Whether to delay table rendering, requires manual call to refreshColumns() to render | boolean | false | - |
 | `[scroll]` | Whether table can be scrolled in x/y direction, x or y can be a string that indicates the width and height of table body | `{ y?: string; x?: string }` | - | - |
 | `[virtualScroll]` | Enable virtual scroll mode，work with `[nzScroll]` | `boolean` | `false` | ✅ |
 | `[virtualItemSize]` | The size of the items in the list, same as [cdk itemSize](https://material.angular.io/cdk/scrolling/api) | `number` | `54` | ✅ |

--- a/packages/abc/st/index.zh-CN.md
+++ b/packages/abc/st/index.zh-CN.md
@@ -66,6 +66,7 @@ module: import { STModule } from '@delon/abc/st';
 | `[loading]` | 页面是否加载中，当指定 `null` 由 st 受控 | `boolean | null` | `null` | - |
 | `[loadingIndicator]` | 加载指示符 | `TemplateRef<void>` | - | ✅ |
 | `[loadingDelay]` | 延迟显示加载效果的时间（防止闪烁） | `number` | `0` | ✅ |
+| `[delay]` | 是否延迟渲染表格,需手动调用`refreshColumns()`渲染 | `boolean` | `false` | - |
 | `[scroll]` | 横向或纵向支持滚动，也可用于指定滚动区域的宽高度：`{ x: "300px", y: "300px" }` | `{ y?: string; x?: string }` | - | - |
 | `[virtualScroll]` | 是否启用虚拟滚动模式，与 `[nzScroll]` 配合使用 | `boolean` | `false` | ✅ |
 | `[virtualItemSize]` | 虚拟滚动时每一列的高度，与 [cdk itemSize](https://material.angular.io/cdk/scrolling/api) 相同 | `number` | `54` | ✅ |

--- a/packages/abc/st/st.component.ts
+++ b/packages/abc/st/st.component.ts
@@ -158,6 +158,7 @@ export class STComponent implements AfterViewInit, OnChanges {
     this.updateTotalTpl();
   }
   @Input() data?: string | STData[] | Observable<STData[]>;
+  @Input() delay?: boolean = false;
   @Input() columns?: STColumn[] | null;
   @Input() contextmenu?: STContextmenuFn | null;
   @Input({ transform: (v: unknown) => numberAttribute(v, 10) }) ps = 10;
@@ -894,7 +895,7 @@ export class STComponent implements AfterViewInit, OnChanges {
   }
 
   ngAfterViewInit(): void {
-    this.refreshColumns();
+    if (!this.delay) this.refreshColumns();
     if (!this.req.lazyLoad) this.loadPageData().subscribe();
     this.inied = true;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
added a new [delay] property to the ST component. that allows delayed table rendering.
When set to true, the table will not render automatically, and requires a manual call to refreshColumns() to trigger the rendering.

Example usage:
```
@Component({
  template: `
    <st #st [delay]="true"></st>
  `
})
export class MyComponent {
  @ViewChild('st') st!: STComponent;
  
  renderTable() {
    this.st.refreshColumns();
  }
}
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
