### PR TITLE
fix(theme): preserve sidebar collapsed state on page refresh

### DIFF
--- a/packages/theme/layout-default/layout.service.spec.ts
+++ b/packages/theme/layout-default/layout.service.spec.ts
@@ -1,4 +1,6 @@
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
 
 import { AlainThemeModule, SettingsService } from '@delon/theme';
 
@@ -36,5 +38,40 @@ describe('theme: #LayoutDefaultService', () => {
     expect(srv.collapsedIcon()).toBe('menu-fold');
     srv.toggleCollapsed(false);
     expect(srv.collapsedIcon()).toBe('menu-unfold');
+  });
+
+  it('should preserve collapsed state on page refresh on desktop #2630', () => {
+    // Simulate page refresh: localStorage already has collapsed=true from user preference
+    localStorage.setItem('layout', JSON.stringify({ collapsed: true, fixed: true, boxed: false, lang: null }));
+
+    // Provide a mock BreakpointObserver that simulates desktop (isMatched returns false)
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AlainThemeModule],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useFactory: () => {
+            const mock = jasmine.createSpyObj('BreakpointObserver', ['observe', 'isMatched']);
+            mock.isMatched.and.returnValue(false);
+            mock.observe.and.returnValue(
+              new Observable<BreakpointState>(subscriber => {
+                subscriber.next({ matches: false, breakpoints: {} });
+              })
+            );
+            return mock;
+          }
+        }
+      ]
+    });
+
+    const settings = TestBed.inject(SettingsService);
+    // Before LayoutDefaultService is created, settings should read collapsed=true from localStorage
+    expect(settings.layout.collapsed).toBe(true);
+
+    // LayoutDefaultService constructor calls checkMedia with isMatched=false (desktop)
+    // It should NOT overwrite the persisted collapsed state
+    TestBed.inject(LayoutDefaultService);
+    expect(settings.layout.collapsed).toBe(true);
   });
 });

--- a/packages/theme/layout-default/layout.service.ts
+++ b/packages/theme/layout-default/layout.service.ts
@@ -48,7 +48,11 @@ export class LayoutDefaultService {
   }
 
   private checkMedia(value: boolean): void {
-    this.settings.setLayout('collapsed', value);
+    // 仅当匹配媒体（移动端）时自动折叠侧边栏
+    // 不匹配时（桌面端）不应覆盖用户已持久化的 collapsed 偏好
+    if (value) {
+      this.settings.setLayout('collapsed', true);
+    }
   }
 
   /**


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Description

修复侧边栏折叠状态在页面刷新后丢失的问题。

### Root Cause
`LayoutDefaultService.checkMedia()` 在构造时无条件调用 `setLayout('collapsed', value)`，桌面端（`isMatched` 返回 `false`）会覆盖用户已持久化到 `localStorage` 的 `collapsed: true`。

### Fix
`checkMedia()` 仅在移动端匹配时自动折叠侧边栏，桌面端不再覆盖用户偏好。

### Test
新增回归测试验证：模拟桌面端场景，确保用户持久化的 `collapsed: true` 不被构造初始覆盖。

close https://github.com/ng-alain/ng-alain/issues/2630

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>