### PR TITLE
fix(form:cascader): set input id so <label for> resolves

### DIFF
--- a/packages/form/widgets/cascader/widget.spec.ts
+++ b/packages/form/widgets/cascader/widget.spec.ts
@@ -129,4 +129,32 @@ describe('form: widget: cascader', () => {
       page.asyncEnd();
     }));
   });
+
+  describe('[accessibility]', () => {
+    // The sf-item-wrap renders `<label for="_sf-N">`, but the inner `<input>` of
+    // nz-cascader must carry that same id so the label resolves.
+    it('should set id on inner input so <label for> resolves', fakeAsync(() => {
+      page
+        .newSchema({
+          properties: {
+            a: {
+              type: 'number',
+              title: 'Location',
+              ui: { widget },
+              enum: [{ value: 1, label: 'Zhejiang', parent: 0 }]
+            }
+          }
+        })
+        .dc(1);
+
+      const labelEl = page.getEl('label[for]');
+      const forId = labelEl.getAttribute('for')!;
+      expect(forId).toMatch(/^_sf-\d+$/);
+
+      const inputEl = document.querySelector('nz-cascader input') as HTMLInputElement;
+      expect(inputEl).not.toBeNull();
+      expect(inputEl.id).toBe(forId);
+      page.asyncEnd();
+    }));
+  });
 });

--- a/packages/form/widgets/cascader/widget.ts
+++ b/packages/form/widgets/cascader/widget.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ControlUIWidget, DelonFormModule, SFSchemaEnum, SFValue, getData, toBool } from '@delon/form';
@@ -52,6 +52,8 @@ import type { SFCascaderWidgetSchema } from './schema';
 export class CascaderWidget extends ControlUIWidget<SFCascaderWidgetSchema> implements OnInit {
   static readonly KEY = 'cascader';
 
+  private readonly host = inject(ElementRef<HTMLElement>);
+
   clearText!: string;
   showArrow!: boolean;
   showInput!: boolean;
@@ -71,11 +73,27 @@ export class CascaderWidget extends ControlUIWidget<SFCascaderWidgetSchema> impl
     }
   }
 
-  reset(value: SFValue): void {
+  override afterViewInit(): void {
+    // nz-cascader renders its inner <input> asynchronously; defer one microtask
+    // so we can set the id that sf-item-wrap's <label for> points to.
+    Promise.resolve().then(() => this.syncInputId());
+  }
+
+  override reset(value: SFValue): void {
     getData(this.schema, {}, value).subscribe(list => {
       this.data = list;
       this.detectChanges();
+      // The input element may be recreated after data loads; re-sync its id.
+      Promise.resolve().then(() => this.syncInputId());
     });
+  }
+
+  private syncInputId(): void {
+    if (!this.id) return;
+    const input = (this.host.nativeElement as HTMLElement).querySelector('input');
+    if (input) {
+      input.id = this.id;
+    }
   }
 
   _visibleChange(status: boolean): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `CascaderWidget` renders a `<label [attr.for]="id">` via `sf-item-wrap`, but never sets that `id` on the inner `<input>` rendered by `nz-cascader`. As a result the label's `for` attribute points to a non-existent element, which fails the Lighthouse/axe **"Incorrect use of `<label for=FORM_ELEMENT>`"** audit.

Rendered DOM before the fix:

```html
<nz-form-item>
  <div class="ant-form-item-label">
    <label for="_sf-0"><span>Location</span></label>  <!-- for points to _sf-0 -->
  </div>
  <nz-form-control>
    <nz-cascader>
      <input type="text" />  <!-- id is empty -->
    </nz-cascader>
  </nz-form-control>
</nz-form-item>
```

`document.getElementById('_sf-0')` returns `null` → the `<label for>` is broken and screen readers cannot associate the label with the control.

This is the same class of accessibility bug that was fixed for the `abc:se` widget in #1993 (commit 61cbe73, v21.1.0), but the `form:cascader` widget was not covered.

> **Why the `se` approach does not apply directly:** the `se` fix sets the id on the control's `elementRef` (a native `<input>`), which is labelable. The `nz-cascader` host element is a custom element and **not labelable**, so the id must be set on the inner `<input>` it renders — which requires querying the DOM after `nz-cascader` has rendered.

Issue Number: N/A

## What is the new behavior?

The widget overrides `afterViewInit()` to set the widget `id` on the inner `<input>` rendered by `nz-cascader` (deferred one microtask so the input exists), and re-syncs it after `reset()` since the input may be recreated when data loads.

```ts
override afterViewInit(): void {
  Promise.resolve().then(() => this.syncInputId());
}

override reset(value: SFValue): void {
  getData(this.schema, {}, value).subscribe(list => {
    this.data = list;
    this.detectChanges();
    Promise.resolve().then(() => this.syncInputId());
  });
}

private syncInputId(): void {
  if (!this.id) return;
  const input = (this.host.nativeElement as HTMLElement).querySelector('input');
  if (input) {
    input.id = this.id;
  }
}
```

Now the inner input carries the same id the `<label for>` points to, and the Lighthouse audit passes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

The change only adds an `id` attribute to an existing `<input>`; no public API, selector, or behavior changes.

## Other information

- Regression test added in `widget.spec.ts` under a new `[accessibility]` describe block, asserting that the inner `<input>` id matches the `<label for>` value.
- Full test suite passes: 1896 SUCCESS, 0 FAILED (7 pre-existing skips).
- `tsc -p packages/tsconfig.json --noEmit` and ESLint both clean.