### PR TITLE
fix(theme:layout-default-nav): use stable track expression to avoid NG0956

### DIFF
--- a/packages/theme/layout-default/layout-header.component.ts
+++ b/packages/theme/layout-default/layout-header.component.ts
@@ -12,7 +12,7 @@ import { LayoutDefaultService } from './layout.service';
   selector: 'layout-default-header',
   template: `
     <ng-template #render let-ls>
-      @for (i of ls; track $index) {
+      @for (i of ls; track i) {
         <li [class.hidden-mobile]="i.hidden() === 'mobile'" [class.hidden-pc]="i.hidden() === 'pc'">
           <ng-container *ngTemplateOutlet="i.host()" />
         </li>

--- a/packages/theme/layout-default/layout-nav.component.ts
+++ b/packages/theme/layout-default/layout-nav.component.ts
@@ -67,7 +67,7 @@ const FLOATINGCLS = 'sidebar-nav__floating';
       }
     </ng-template>
     <ng-template #tree let-ls>
-      @for (i of ls; track $index) {
+      @for (i of ls; track i._id) {
         @if (i._hidden !== true) {
           @if (i.render_type === 'divider') {
             <li class="sidebar-nav__divider"></li>
@@ -126,7 +126,7 @@ const FLOATINGCLS = 'sidebar-nav__floating';
       }
     </ng-template>
     <ul class="sidebar-nav">
-      @for (group of list(); track $index) {
+      @for (group of list(); track group._id) {
         @if (group.group) {
           <li class="sidebar-nav__item sidebar-nav__group-title">
             <span [innerHTML]="group._text"></span>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `@for` loops in `layout-default-nav` and `layout-default-header` use `track $index`. When the `MenuService` signal emits a **new array reference** on each change detection cycle (which it does, since signals like `list()` return new references on resume), Angular sees the same indices pointing to objects with new identities and triggers the **NG0956** warning:

```
NG0956: The configured tracking expression (track by identity) caused re-creation
of the entire collection of size N. This is an expensive operation requiring
destruction and subsequent creation of DOM nodes, directives, components etc.
Please review the "track expression" and make sure that it uniquely identifies
items in a collection.
```

This warning appears on every navigation/CD tick in any ng-alain app with a menu, polluting the dev console and causing unnecessary DOM teardown/rebuild of the entire sidebar nav.

## What is the new behavior?

Use stable tracking expressions that uniquely identify items:

- **`layout-nav.component.ts`** (menu items and groups): `track $index` → `track i._id` / `track group._id`. The `_id` field is always assigned by `MenuService.resume()` (starts at 1, monotonically increments — see `menu.service.ts` line 141), so it is a stable unique identifier per `MenuInner`.
- **`layout-header.component.ts`** (header items): `track $index` → `track i`. This iterates `LayoutDefaultHeaderItemComponent[]` (component instances) which have no natural id field; tracking by instance identity is Angular's recommended default when no natural id exists — it only recreates when the actual instance changes, not on every array rebuild.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Only the `track` expression changes; no template structure, bindings, or public API changes.

## Other information

- Full test suite passes: **1895 SUCCESS, 0 FAILED (7 pre-existing skips)**.
- `tsc -p packages/tsconfig.json --noEmit` and ESLint both clean.
- This is the same class of issue as Angular's general recommendation against `track $index` (https://angular.dev/api/core/TrackByFunction) — `$index` should only be used when the collection is static.