### PR TITLE
feat(sf): support changeOnWheel in number widget

### DIFF
--- a/packages/form/src/widgets/number/demo/simple.md
+++ b/packages/form/src/widgets/number/demo/simple.md
@@ -38,7 +38,8 @@ export class DemoComponent {
       integer: { type: 'integer', default: 10, ui: { widgetWidth: '100%' } as SFNumberWidgetSchema },
       unit: { type: 'number', default: 10, ui: { unit: '%' } as SFNumberWidgetSchema },
       prefix: { type: 'number', default: 10, ui: { prefix: '$' } as SFNumberWidgetSchema },
-      hideStep: { type: 'number', default: 10, ui: { hideStep: true } as SFNumberWidgetSchema }
+      hideStep: { type: 'number', default: 10, ui: { hideStep: true } as SFNumberWidgetSchema },
+      changeOnWheel: { type: 'number', default: 10, ui: { changeOnWheel: false } as SFNumberWidgetSchema }
     }
   };
 

--- a/packages/form/src/widgets/number/index.en-US.md
+++ b/packages/form/src/widgets/number/index.en-US.md
@@ -31,6 +31,7 @@ Enter a number within certain range with the mouse or keyboard.
 | `[precision]` | precision of input value | - | - |
 | `[widgetWidth]` | Specify `nz-number` width | `number, string` | `90` |
 | `[hideStep]` | Hide step icon | `boolean` | `false` |
+| `[changeOnWheel]` | Whether to enable mouse wheel control | `boolean` | `true` |
 
 ## QA
 

--- a/packages/form/src/widgets/number/index.zh-CN.md
+++ b/packages/form/src/widgets/number/index.zh-CN.md
@@ -34,6 +34,7 @@ order: 5
 | `[precision]` | 等同 `nzPrecision` | - | - |
 | `[widgetWidth]` | 指定 `nz-number` 宽度 | `number, string` | `90` |
 | `[hideStep]` | 隐藏步数操作区 | `boolean` | `false` |
+| `[changeOnWheel]` | 是否启用鼠标滚轮控制 | `boolean` | `true` |
 | `[change]` | 变更事件 | `(val?: number) => void` | - |
 
 ## QA

--- a/packages/form/src/widgets/number/number.widget.spec.ts
+++ b/packages/form/src/widgets/number/number.widget.spec.ts
@@ -2,6 +2,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync } from '@angular/core/testing';
 
 import { createTestContext } from '@delon/testing';
+import { NzInputNumberComponent } from 'ng-zorro-antd/input-number';
 
 import { SFNumberWidgetSchema } from './schema';
 import { configureSFTestSuite, SFPage, TestFormComponent } from '../../../spec/base.spec';
@@ -146,6 +147,23 @@ describe('form: widget: number', () => {
       page.typeChar(1, 'input');
       expect(ui.change).toHaveBeenCalled();
     }));
+
+    describe('#changeOnWheel', () => {
+      it('default should be true', fakeAsync(() => {
+        const s: SFSchema = { properties: { a: { type: 'number' } } };
+        page.newSchema(s);
+        const comp = page.getWidget<NzInputNumberComponent>('nz-input-number');
+        expect(comp.nzChangeOnWheel()).toBe(true);
+      }));
+      it('should be false when set ui.changeOnWheel', fakeAsync(() => {
+        const s: SFSchema = {
+          properties: { a: { type: 'number', ui: { changeOnWheel: false } as SFNumberWidgetSchema } }
+        };
+        page.newSchema(s);
+        const comp = page.getWidget<NzInputNumberComponent>('nz-input-number');
+        expect(comp.nzChangeOnWheel()).toBe(false);
+      }));
+    });
 
     describe('#widgetWidth', () => {
       it('width number', fakeAsync(() => {

--- a/packages/form/src/widgets/number/number.widget.ts
+++ b/packages/form/src/widgets/number/number.widget.ts
@@ -26,6 +26,7 @@ import { ControlUIWidget } from '../../widget';
       [nzParser]="parser"
       [nzPrecision]="ui.precision ?? null"
       [nzPlaceHolder]="ui.placeholder ?? ''"
+      [nzChangeOnWheel]="ui.changeOnWheel ?? true"
       [style.width]="width"
       [class.ant-input-number__hide-step]="ui.hideStep"
     />

--- a/packages/form/src/widgets/number/schema.ts
+++ b/packages/form/src/widgets/number/schema.ts
@@ -43,6 +43,13 @@ export interface SFNumberWidgetSchema extends SFUISchemaItem {
   hideStep?: boolean;
 
   /**
+   * Whether to enable mouse wheel control, default is `true`
+   *
+   * 是否启用鼠标滚轮控制，默认 `true`
+   */
+  changeOnWheel?: boolean;
+
+  /**
    * 变更事件
    */
   change?: (val?: number) => void;


### PR DESCRIPTION
## PR Checklist
- [x] 提交信息符合 [commit message 规范](https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit)
- [x] 已通过 lint 与 form 包全部单测（278 个全部通过）

## 变更说明

`nz-input-number` 自 ng-zorro v21.0.0 起默认支持鼠标滚轮改值（`nzChangeOnWheel`，默认 `true`），sf number widget 未透传该能力，用户在滚动大表单页面时可能误改数值。本次为 `SFNumberWidgetSchema` 新增 `changeOnWheel` 属性（默认 `true`），可显式关闭：

```ts
const ui: SFNumberWidgetSchema = {
  widget: 'number',
  changeOnWheel: false // 滚动页面时不再误改数值
};
```

## 涉及文件

- `packages/form/src/widgets/number/schema.ts`：新增 `changeOnWheel?: boolean`
- `packages/form/src/widgets/number/number.widget.ts`：绑定 `[nzChangeOnWheel]="ui.changeOnWheel ?? true"`
- `packages/form/src/widgets/number/number.widget.spec.ts`：新增 2 个测试（默认 true / 显式 false）
- `index.zh-CN.md` / `index.en-US.md`：文档
- `demo/simple.md`：示例

close ng-alain/ng-alain#2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)