### PR TITLE
feat(st:pop): support title as function

### DIFF
--- a/packages/abc/st/st-td.component.html
+++ b/packages/abc/st/st-td.component.html
@@ -8,16 +8,16 @@
   }
 </ng-template>
 <ng-template #btnItemTpl let-i>
-  @if (i.pop) {
+  @if (i.pop && _popTitle(i); as title) {
     @let pop = i.pop;
     <a
       nz-popconfirm
-      [nzPopconfirmTitle]="pop.title"
+      [nzPopconfirmTitle]="title"
       [nzIcon]="pop.icon"
       [nzCondition]="pop.condition(i)"
-      [nzCancelText]="pop.cancelText"
-      [nzOkText]="pop.okText"
-      [nzOkType]="pop.okType"
+      [nzCancelText]="pop.cancelText ?? null"
+      [nzOkText]="pop.okText ?? null"
+      [nzOkType]="pop.okType ?? 'primary'"
       (nzOnConfirm)="_btn(i)"
       class="st__btn-text"
       [class]="i._className"

--- a/packages/abc/st/st.component.ts
+++ b/packages/abc/st/st.component.ts
@@ -61,6 +61,7 @@ import type {
   STClickRowClassNameType,
   STColumn,
   STColumnButton,
+  STColumnButtonPop,
   STColumnSafeType,
   STColumnSelection,
   STContextmenuFn,
@@ -155,6 +156,20 @@ export class STTdComponent {
   _stopPropagation(ev: Event): void {
     ev.preventDefault();
     ev.stopPropagation();
+  }
+
+  /**
+   * 解析气泡确认框标题
+   * - `title` 为函数时：以返回值为标题，`null`/`undefined` 表示不显示气泡确认框
+   */
+  _popTitle(btn: STColumnButton): string | null {
+    const pop = btn.pop;
+    if (pop == null || pop === false) return null;
+    const title = (pop as STColumnButtonPop).title;
+    if (typeof title === 'function') {
+      return title({ item: this.i, btn, column: this.c }) ?? null;
+    }
+    return title ?? null;
   }
 
   _btn(btn: STColumnButton, ev?: Event): void {

--- a/packages/abc/st/st.interfaces.ts
+++ b/packages/abc/st/st.interfaces.ts
@@ -784,7 +784,7 @@ export interface STColumnButton<T extends STData = any> {
   /**
    * 气泡确认框参数，若 `string` 类型表示标题
    */
-  pop?: boolean | string | STColumnButtonPop;
+  pop?: boolean | string | STColumnButtonPop<T>;
   /**
    * 对话框参数
    */
@@ -919,8 +919,9 @@ export interface STColumnButtonDrawerConfig {
 export interface STColumnButtonPop<T extends STData = any> {
   /**
    * Title of the popover, default: `确认删除吗？`
+   * - 函数：以返回值为标题，`null`/`undefined` 表示不显示气泡确认框
    */
-  title?: string;
+  title?: string | STColumnButtonPopFn<T>;
 
   titleI18n?: string;
 
@@ -985,6 +986,15 @@ export interface STColumnButtonPop<T extends STData = any> {
    */
   condition?: (item: T) => boolean;
 }
+
+/**
+ * 气泡确认框标题函数，返回 `null`/`undefined` 表示不显示气泡确认框
+ */
+export type STColumnButtonPopFn<T extends STData = any> = (data: {
+  item: T;
+  btn: STColumnButton<T>;
+  column: STColumn;
+}) => string | null | undefined;
 
 export interface STReqReNameType {
   pi?: string;

--- a/packages/abc/st/test/st-column-source.spec.ts
+++ b/packages/abc/st/test/st-column-source.spec.ts
@@ -10,7 +10,7 @@ import { STColumnSource, STColumnSourceProcessOptions } from '../st-column-sourc
 import { STRowSource } from '../st-row.directive';
 import { STWidgetRegistry } from '../st-widget';
 import { ST_DEFAULT_CONFIG } from '../st.config';
-import { STColumn, STColumnButtonPop, STIcon, STResizable, STWidthMode } from '../st.interfaces';
+import { STColumn, STColumnButtonPop, STColumnButtonPopFn, STIcon, STResizable, STWidthMode } from '../st.interfaces';
 import { _STColumn } from '../st.types';
 
 const i18nResult = 'zh';
@@ -462,6 +462,12 @@ describe('st: column-source', () => {
           const pop = newColumns[0].buttons![0].pop as STColumnButtonPop;
           expect(pop != null).toBe(true);
           expect(pop.condition!(null!)).toBe(true);
+        });
+        it('should be keep title function', () => {
+          const fn: STColumnButtonPopFn = () => 'aaa';
+          const newColumns = srv.process([{ title: '', buttons: [{ text: '', pop: { title: fn } }] }], options).columns;
+          const pop = newColumns[0].buttons![0].pop as STColumnButtonPop;
+          expect(typeof pop.title).toBe('function');
         });
       });
       describe('#icon', () => {

--- a/packages/abc/st/test/st.spec.ts
+++ b/packages/abc/st/test/st.spec.ts
@@ -457,6 +457,41 @@ describe('abc: st', () => {
           expect(columns[0].buttons![0].click).toHaveBeenCalled();
           page.asyncEnd();
         }));
+        it(`should be pop confirm title via pop function`, fakeAsync(() => {
+          const columns: STColumn[] = [
+            {
+              title: '',
+              buttons: [
+                {
+                  text: 'del',
+                  pop: { title: ({ item }) => `确定删除 ${item.name} 吗？` },
+                  click: jasmine.createSpy()
+                }
+              ]
+            }
+          ];
+          page.updateColumn(columns).expectCell('del', 1, 1, '[nz-popconfirm]').cd();
+          page.clickCell(1, 1, '.st__btn-text').cd();
+          expect(document.querySelector('.ant-popover .ant-popover-message-title')!.textContent!.trim()).toBe(
+            `确定删除 ${USERS[0].name} 吗？`
+          );
+          page.click('.ant-popover-buttons .ant-btn-primary').cd();
+          expect(columns[0].buttons![0].click).toHaveBeenCalled();
+          page.asyncEnd();
+        }));
+        it(`should be normal button when pop function return null`, fakeAsync(() => {
+          const clickSpy = jasmine.createSpy();
+          const columns: STColumn[] = [
+            {
+              title: '',
+              buttons: [{ text: 'del', pop: { title: () => null }, click: clickSpy }]
+            }
+          ];
+          page.updateColumn(columns).expectCell('del', 1, 1, '.st__btn-text').cd();
+          page.clickCell(1, 1, '.st__btn-text').cd();
+          expect(clickSpy).toHaveBeenCalled();
+          page.asyncEnd();
+        }));
         it('should custom render text via format', fakeAsync(() => {
           const columns: STColumn[] = [
             {


### PR DESCRIPTION
STColumnButtonPop.title 支持函数形式，以返回值为标题，null/undefined 表示不显示气泡确认框

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
