### PR TITLE
chore(schematics): migrate to bundler moduleResolution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- [ ] 移除 ignoreDeprecations
 - [ ] @ViewChild 也要 signalr 化
 - [ ] 已经 signalr 化以后，是否还需要 fixture.detectChanges(); 呢？
 1、先查资料

--- a/schematics/application/index.ts
+++ b/schematics/application/index.ts
@@ -1,5 +1,4 @@
 import { strings } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import {
   apply,
   chain,
@@ -14,7 +13,7 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { updateWorkspace } from '@schematics/angular/utility/workspace';
+import { ProjectDefinition, updateWorkspace } from '@schematics/angular/utility/workspace';
 
 import { getLangData } from '../core/lang.config';
 import {

--- a/schematics/plugin/plugin.icon.ts
+++ b/schematics/plugin/plugin.icon.ts
@@ -1,9 +1,7 @@
 import { strings } from '@angular-devkit/core';
 import { Rule, Tree } from '@angular-devkit/schematics';
 import { findNodes, getDecoratorMetadata } from '@schematics/angular/utility/ast-utils';
-import { parseFragment } from 'parse5';
-import type { Attribute } from 'parse5/dist/common/token';
-import type { Element } from 'parse5/dist/tree-adapters/default';
+import { parseFragment, DefaultTreeAdapterTypes } from 'parse5';
 import * as ts from 'typescript';
 
 import { getSourceFile } from '../utils';
@@ -85,7 +83,7 @@ ATTRIBUTE_NAMES.forEach(key => {
 function findIcons(html: string): string[] {
   const res: string[] = [];
   const doc = parseFragment(html);
-  const visitNodes = (nodes: Element[]): void => {
+  const visitNodes = (nodes: DefaultTreeAdapterTypes.Element[]): void => {
     nodes.forEach(node => {
       if (node.attrs) {
         const classIcon = genByClass(node);
@@ -97,16 +95,16 @@ function findIcons(html: string): string[] {
       }
 
       if (node.childNodes) {
-        visitNodes(node.childNodes as Element[]);
+        visitNodes(node.childNodes as DefaultTreeAdapterTypes.Element[]);
       }
     });
   };
 
-  visitNodes(doc.childNodes as Element[]);
+  visitNodes(doc.childNodes as DefaultTreeAdapterTypes.Element[]);
   return res;
 }
 
-function genByClass(node: Element): string | null {
+function genByClass(node: DefaultTreeAdapterTypes.Element): string | null {
   const attr = node.attrs.find(a => a.name === 'class');
   if (!attr || !attr.value) return null;
   const match = attr.value.match(/anticon(-\w+)+/g);
@@ -114,7 +112,7 @@ function genByClass(node: Element): string | null {
   return match[0];
 }
 
-function genByComp(node: Element): string[] | null {
+function genByComp(node: DefaultTreeAdapterTypes.Element): string[] | null {
   if (node.nodeName != 'nz-icon' && !node.attrs.find(attr => attr.name === 'nz-icon')) return null;
 
   const type = node.attrs.find(attr => ['type', '[type]', 'nztype', '[nztype]'].includes(attr.name));
@@ -130,7 +128,7 @@ function genByComp(node: Element): string[] | null {
   return types.flatMap(a => themes.map(b => `${a}#${b}`));
 }
 
-function genByAttribute(node: Element): string[] | null {
+function genByAttribute(node: DefaultTreeAdapterTypes.Element): string[] | null {
   if (!ATTRIBUTE_NAMES.includes(node.nodeName as keyof typeof ATTRIBUTES)) return null;
 
   const attributes = ATTRIBUTES[node.nodeName as keyof typeof ATTRIBUTES];
@@ -143,7 +141,7 @@ function genByAttribute(node: Element): string[] | null {
   return types;
 }
 
-function getNgValue(attr: Attribute): string[] | null {
+function getNgValue(attr: any): string[] | null {
   if (!attr) return null;
 
   const str = attr.value.trim();

--- a/schematics/plugin/plugin.rtl.ts
+++ b/schematics/plugin/plugin.rtl.ts
@@ -1,8 +1,8 @@
 import { isStandaloneSchematic } from '@angular/cdk/schematics';
 
 import { normalize } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import { apply, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectDefinition } from '@schematics/angular/utility/workspace';
 
 import {
   addImportToModule,

--- a/schematics/sta/index.ts
+++ b/schematics/sta/index.ts
@@ -1,6 +1,6 @@
 import { normalize } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import { Rule, SchematicsException, Tree, chain, SchematicContext } from '@angular-devkit/schematics';
+import { ProjectDefinition } from '@schematics/angular/utility/workspace';
 import { rmSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { parse } from 'jsonc-parser';
 import { color } from 'listr2';

--- a/schematics/tsconfig.json
+++ b/schematics/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "lib": ["es2017", "dom"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "../dist/ng-alain",
     "noEmitOnError": false,
     "resolveJsonModule": true,

--- a/schematics/tsconfig.spec.json
+++ b/schematics/tsconfig.spec.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "lib": ["es2017", "dom"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "../dist/schematics-test",
     "noEmitOnError": false,
     "skipDefaultLibCheck": true,

--- a/schematics/utils/alain.ts
+++ b/schematics/utils/alain.ts
@@ -1,5 +1,4 @@
 import { strings, normalize } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import {
   apply,
   applyTemplates,
@@ -20,6 +19,7 @@ import { InsertChange } from '@schematics/angular/utility/change';
 import { buildRelativePath, findModuleFromOptions, ModuleOptions } from '@schematics/angular/utility/find-module';
 import { parseName } from '@schematics/angular/utility/parse-name';
 import { validateHtmlSelector } from '@schematics/angular/utility/validation';
+import { ProjectDefinition } from '@schematics/angular/utility/workspace';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/schematics/utils/html.ts
+++ b/schematics/utils/html.ts
@@ -1,6 +1,6 @@
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { InsertChange } from '@schematics/angular/utility/change';
+import { ProjectDefinition } from '@schematics/angular/utility/workspace';
 import * as parse5 from 'parse5';
 
 import { BUILD_TARGET_BUILD, getProjectTarget } from './workspace';


### PR DESCRIPTION
TS 6.0 deprecates node10 resolution (TS5107). Replaced deep imports with public APIs (@schematics/angular/utility/workspace) so that `module: commonjs` + `moduleResolution: bundler` works (valid since TS 6.0) while keeping CommonJS output, and removed the now-unneeded `ignoreDeprecations`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
